### PR TITLE
Shutdown ExecutorServices on tests

### DIFF
--- a/src/test/java/com/mitchellbosecke/pebble/CacheTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CacheTest.java
@@ -168,6 +168,7 @@ public class CacheTest extends AbstractTest {
 		}
 		// Wait for them all to complete
 		semaphore.acquire(numOfConcurrentThreads);
+		es.shutdown();
 		assertEquals(0, totalFailed.intValue());
 	}
 

--- a/src/test/java/com/mitchellbosecke/pebble/ConcurrencyTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ConcurrencyTest.java
@@ -197,6 +197,7 @@ public class ConcurrencyTest extends AbstractTest {
 		}
 		// Wait for them all to complete
 		semaphore.acquire(numOfConcurrentThreads);
+		es.shutdown();
 		assertEquals(0, totalFailed.intValue());
 	}
 }


### PR DESCRIPTION
Currently, the ExecutorServices used on tests are not shutdown after use.

This may cause the thread pools not to be released, resulting in `java.lang.OutOfMemoryError: unable to create native thread`.

This pull requests fixes those issues.
