### PR TITLE
Add "subscript syntax" support for accessing attributes

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/parser/ExpressionParser.java
+++ b/src/main/java/com/mitchellbosecke/pebble/parser/ExpressionParser.java
@@ -330,7 +330,8 @@ public class ExpressionParser {
 		while (true) {
 			current = stream.current();
 
-			if (current.test(Token.Type.PUNCTUATION, ".")) {
+			if (current.test(Token.Type.PUNCTUATION, ".")
+			    || current.test(Token.Type.PUNCTUATION, "[")) {
 
 				// a period represents getting an attribute from a variable or
 				// calling a method
@@ -417,7 +418,21 @@ public class ExpressionParser {
 
 			node = new GetAttributeExpression(node, token.getValue());
 
+		} else if (stream.current().test(Token.Type.PUNCTUATION, "[")) {
+			// skip over opening '[' bracket
+			stream.next();
+
+			// treat the string value inside the brackets just the same as we
+			// would an attribute name following a '.', except that the
+			// attribute name gathered this way is NOT held to the same naming
+			// restrictions (e.g. can include hyphens '-')
+			Token token = stream.expect(Token.Type.STRING);
+			node = new GetAttributeExpression(node, token.getValue());
+
+			// move past the closing ']' bracket
+			stream.expect(Token.Type.PUNCTUATION, "]");
 		}
+
 		return node;
 	}
 

--- a/src/test/java/com/mitchellbosecke/pebble/AttributeSubscriptSyntaxText.java
+++ b/src/test/java/com/mitchellbosecke/pebble/AttributeSubscriptSyntaxText.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.Loader;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class AttributeSubscriptSyntaxText extends AbstractTest {
+	@Test
+	public void testAccessingValueWithSubscript() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{{ person['first-name'] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("first-name", "Bob");
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+
+	@Test
+	public void testAccessingNestedValuesWithSubscript() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{{ person['name']['first'] }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("name", new HashMap<String, Object>() {
+					{
+						put("first", "Bob");
+					}
+				});
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+
+	@Test
+	public void testMixAndMatchingAttributeSyntax() throws PebbleException, IOException {
+		Loader loader = new StringLoader();
+		PebbleEngine pebble = new PebbleEngine(loader);
+		pebble.setStrictVariables(false);
+
+		String source = "{{ person['name'].first }}";
+		PebbleTemplate template = pebble.getTemplate(source);
+
+		Map<String, Object> context = new HashMap<>();
+		context.put("person", new HashMap<String, Object>() {
+			{
+				put("name", new HashMap<String, Object>() {
+					{
+						put("first", "Bob");
+					}
+				});
+			}
+		});
+
+		Writer writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+
+
+		source = "{{ person.name['first'] }}";
+		template = pebble.getTemplate(source);
+
+		writer = new StringWriter();
+		template.evaluate(writer, context);
+		assertEquals("Bob", writer.toString());
+	}
+}


### PR DESCRIPTION
This adds an alternate syntax for accessing attributes for values inside the context map. It would be very useful if your context map contained keys with otherwise invalid characters in the key name (such as hyphens).

Currently

```
{{ person.first-name }}
```

results in:

```
Exception in thread "main" java.lang.RuntimeException: invalid operands for mathematical operator [+]
```

With this addition, you can now do this:

```
{{ person['first-name'] }}
```

And can chain them together the same way you can access multi-layered nested values with the dot '.' syntax.
