### PR TITLE
Don't Just escape Strings

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
@@ -77,10 +77,10 @@ public class EscapeFilter implements Filter {
     }
 
     public Object apply(Object inputObject, Map<String, Object> args) {
-        if (!(inputObject instanceof String)) {
+        if (inputObject == null || inputObject instanceof SafeString) {
             return inputObject;
         }
-        String input = (String) inputObject;
+        String input = inputObject.toString();
 
         String strategy = defaultStrategy;
 

--- a/src/test/java/com/mitchellbosecke/pebble/EscaperExtensionTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/EscaperExtensionTest.java
@@ -14,6 +14,7 @@ import com.mitchellbosecke.pebble.extension.Function;
 import com.mitchellbosecke.pebble.extension.escaper.EscapingStrategy;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
 import org.junit.Test;
 
 import java.io.IOException;
@@ -81,6 +82,17 @@ public class EscaperExtensionTest extends AbstractTest {
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
         assertEquals("&lt;br /&gt;", writer.toString());
+    }
+
+    @Test
+    public void testAutoescapeNonString() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+        PebbleTemplate template = pebble.getTemplate("{{ text }}");
+        Map<String, Object> context = new HashMap<>();
+        context.put("text", Collections.singletonList("<br />"));
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("[&lt;br /&gt;]", writer.toString());
     }
 
     @Test


### PR DESCRIPTION
Escape anything, and not just `Strings`.

Previously, the `EscapeFilter` would ignore anything that wasn't a String, this
meant that an object being printed could contain some XSS content in its
`toString()` method (e.g standard java collections that contain a string with
XSS) that didn't get escaped, even if the escape filter was used explicitly.
The `EscapeFilter` now converts anything to a `String` with `toString()`, and then
proceeds as normal.

This PR will conflict with #149 and one or other of them will need to be rebased when the other gets merged, I will of course do this when necessary.

Also worth noting that even if there were no merge conflicts, tests would fail after both were to get merged in as `RawString` would no longer be ignored as required by `EscapeFilter` (so this change will also need to be made).