### PR TITLE
restore and deprecate addEscaperSafeFilter

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -404,6 +404,18 @@ public class PebbleEngine {
         }
 
         /**
+         * Marks a particular tag as safe to the built-in escaper extension.
+         *
+         * @param filter The name of the tag to be marked as safe
+         * @return This builder object
+         * @deprecated tags are now escaped by default; this call should be removed
+         */
+        @Deprecated
+        public Builder addEscaperSafeFilter(String filter) {
+            return this;
+        }
+
+        /**
          * Adds an escaping strategy to the built-in escaper extension.
          *
          * @param name     The name of the escaping strategy


### PR DESCRIPTION
This PR restores PebbleEngine Builder's addEscaperSafeFilter as a deprecated no-op, which was removed in a minor release (2.1.0). This allows delaying a breaking API change until a new major version is released.