### PR TITLE
Fix ConcurrentModificationException when importing macros in nested parallels blocks (#182) by snapshotting the importedTemplates passed into EvaluationContext.

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContext.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContext.java
@@ -11,6 +11,7 @@ package com.mitchellbosecke.pebble.template;
 import com.google.common.cache.Cache;
 import com.mitchellbosecke.pebble.cache.BaseTagCacheKey;
 import com.mitchellbosecke.pebble.extension.ExtensionRegistry;
+import java.util.ArrayList;
 
 import java.util.List;
 import java.util.Locale;
@@ -95,7 +96,7 @@ public class EvaluationContext {
         this.extensionRegistry = extensionRegistry;
         this.tagCache = tagCache;
         this.executorService = executorService;
-        this.importedTemplates = importedTemplates;
+        this.importedTemplates = importedTemplates != null ? new ArrayList<PebbleTemplateImpl>(importedTemplates) : null;
         this.scopeChain = scopeChain;
         this.hierarchy = hierarchy;
     }


### PR DESCRIPTION
This patch fixes ConcurrentModificationException when importing macros in nested parallels blocks (#182) by snapshotting the importedTemplates passed into EvaluationContext. 

The benefit of snapshotting the templates is that this way, they don't "leak" to the outer context in case of parallel blocks which is what I would expect. Obviously, it fixes the ConcurrentModificationException as well. 

Furthermore, the patch includes a test for the issue that fails without the patch but passes with it on my system. Unfortunately, the test is done in a little roundabout way as the actual issue (the ConcurrentModificationException) is silently swallowed and doesn't fail the overall template execution (which I would consider a bug in its own right) -- hence, it just does run same same template one time without an Executor and one time with an Executor and compares the result (which isn't guaranteed to fail depending on you hardware - it does however, fail on my system everytime out of 20 runs).  