### PR TITLE
Fix ConcurrentModificationException when importing macros in nested parallels blocks (#182) by seeding the importedTemplates passed into the root EvaluationContext with a CopyOnWriteArrayList instead of an ArrayList.

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplateImpl.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplateImpl.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The actual implementation of a PebbleTemplate
@@ -141,7 +142,7 @@ public class PebbleTemplateImpl implements PebbleTemplate {
 
         EvaluationContext context = new EvaluationContext(this, engine.isStrictVariables(), locale,
                 engine.getExtensionRegistry(), engine.getTagCache(), engine.getExecutorService(),
-                new ArrayList<PebbleTemplateImpl>(), scopeChain, null);
+                new CopyOnWriteArrayList<PebbleTemplateImpl>(), scopeChain, null);
         return context;
     }
 


### PR DESCRIPTION
This patch fixes ConcurrentModificationException when importing macros in nested parallels blocks (#182) by seeding the importedTemplates passed into the root EvaluationContext with a CopyOnWriteArrayList instead of an ArrayList.

The benefit of seeding with a CopyOnWriteArrayList that keeps being passed down is that it potentially saves some memory however,  it does "leak" macros to the outer context in case of parallel blocks which is not what I would expect. Obviously, it fixes the ConcurrentModificationException as well. 

Furthermore, the patch includes a test for the issue that fails without the patch but passes with it on my system. Unfortunately, the test is done in a little roundabout way as the actual issue (the ConcurrentModificationException) is silently swallowed and doesn't fail the overall template execution (which I would consider a bug in its own right) -- hence, it just does run same same template one time without an Executor and one time with an Executor and compares the result (which isn't guaranteed to fail depending on you hardware - it does however, fail on my system everytime out of 20 runs).  