### PR TITLE
Improve handling of null values in boolean logic.

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/IfNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/IfNode.java
@@ -54,6 +54,8 @@ public class IfNode extends AbstractRenderableNode {
                     } catch (ClassCastException ex) {
                         throw new PebbleException(ex, "Expected a Boolean in \"if\" statement", getLineNumber(), self.getName());
                     }
+                } else if(context.isStrictVariables()){
+                    throw new PebbleException(null, "null value given to if statement and strict variables is set to true", getLineNumber(), self.getName());
                 }
 
             } catch (RuntimeException ex) {

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/AndExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/AndExpression.java
@@ -17,8 +17,17 @@ public class AndExpression extends BinaryExpression<Boolean> {
     @SuppressWarnings("unchecked")
     @Override
     public Boolean evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
-        Expression<Boolean> left = (Expression<Boolean>) getLeftExpression();
-        Expression<Boolean> right = (Expression<Boolean>) getRightExpression();
-        return left.evaluate(self, context) && right.evaluate(self, context);
+        Boolean left = ((Expression<Boolean>) getLeftExpression()).evaluate(self, context);
+        Boolean right = ((Expression<Boolean>) getRightExpression()).evaluate(self, context);
+        if(context.isStrictVariables()){
+            if (left == null || right == null)
+                throw new PebbleException(null, "null value used in and operator and strict variables is set to true", getLineNumber(), self.getName());
+        } else {
+            if (left == null)
+                left = false;
+            if (right == null)
+                right = false;
+        }
+        return left && right;
     }
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/OrExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/OrExpression.java
@@ -17,8 +17,17 @@ public class OrExpression extends BinaryExpression<Boolean> {
     @SuppressWarnings("unchecked")
     @Override
     public Boolean evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
-        Expression<Boolean> left = (Expression<Boolean>) getLeftExpression();
-        Expression<Boolean> right = (Expression<Boolean>) getRightExpression();
-        return left.evaluate(self, context) || right.evaluate(self, context);
+        Boolean left = ((Expression<Boolean>) getLeftExpression()).evaluate(self, context);
+        Boolean right = ((Expression<Boolean>) getRightExpression()).evaluate(self, context);
+        if(context.isStrictVariables()){
+            if (left == null || right == null)
+                throw new PebbleException(null, "null value used in or operator and strict variables is set to true", getLineNumber(), self.getName());
+        } else {
+            if (left == null)
+                left = false;
+            if (right == null)
+                right = false;
+        }
+        return left || right;
     }
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/UnaryNotExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/UnaryNotExpression.java
@@ -17,7 +17,13 @@ public class UnaryNotExpression extends UnaryExpression {
     @Override
     public Object evaluate(PebbleTemplateImpl self, EvaluationContext context) throws PebbleException {
         Boolean result = (Boolean) getChildExpression().evaluate(self, context);
-        return !result;
+        if (context.isStrictVariables()){
+            if(result == null)
+                throw new PebbleException(null, "null value given to not() and strict variables is set to true", getLineNumber(), self.getName());
+            return !result;
+        } else {
+            return result == null || !result;
+        }
     }
 
 }


### PR DESCRIPTION
Something that has been frustrating me is the inconsistency in handling `null` values in if statements, and boolean expressions. Namely, `null` is implicitly `false` in `if` blocks, but when used in more complex expressions (using `not`, `and` or `or`), it is treated as an invalid operand. (This leads to iterative changes in templates potentially leading to errors where it makes no sense for that regression to happen).

This PR makes the following changes:
- null values are implicitly false when used with `not`, `or` and `and`.
- In strict mode, `null` values are not allowed in any of these operators, and also now not allowed in an `if` statement: previously, in strict mode this would render `no` rather than throwing an error:
  
  ``` django
  {% if null %}yes{% else %}no{% endif %}
  ```
