### PR TITLE
Throw PebbleException when variable cannot be iterated in a For tag

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
@@ -56,6 +56,11 @@ public class ForNode extends AbstractRenderableNode {
 
         iterable = toIterable(iterableEvaluation);
 
+        if (iterable == null) {
+            throw new PebbleException(null, "Not an iterable object. Value = [" + iterableEvaluation.toString() + "]",
+                getLineNumber(), self.getName());
+        }
+
         Iterator<?> iterator = iterable.iterator();
 
         boolean newScope = false;

--- a/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ArraySyntaxTest extends AbstractTest {
 
@@ -330,6 +331,22 @@ public class ArraySyntaxTest extends AbstractTest {
         Writer writer = new StringWriter();
         template.evaluate(writer, new HashMap<String, Object>());
         assertEquals("BobMariaJohn", writer.toString());
+    }
+
+    @Test
+    public void testForTagInvalidIterable() throws PebbleException, IOException {
+
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+        String source = "{% set myVar = 'somevalue' %}{% for myVal in myVar %}{{ myVal }}{% endfor %}";
+        PebbleTemplate template = pebble.getTemplate(source);
+
+        Writer writer = new StringWriter();
+        try {
+            template.evaluate(writer, new HashMap<String, Object>());
+            fail("Expected PebbleException");
+        } catch (PebbleException e) {
+            assertEquals("Not an iterable object. Value = [somevalue] (" + source + ":1)", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Pebble returns a NullPointerException when passing a non-iterable variable (string, number, ..) to a for loop, making hard the task of finding what is that the developer has written wrong in the template.
This PR tries to address that issue, raising a PebbleException and providing information about the error and the line where it occurred.