### PR TITLE
Allow the set tag to update existing values in parent scopes

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/SetNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/SetNode.java
@@ -30,7 +30,7 @@ public class SetNode extends AbstractRenderableNode {
 
     @Override
     public void render(PebbleTemplateImpl self, Writer writer, EvaluationContext context) throws PebbleException {
-        context.getScopeChain().put(name, value.evaluate(self, context));
+        context.getScopeChain().set(name, value.evaluate(self, context));
     }
 
     @Override

--- a/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
@@ -193,4 +193,41 @@ public class ScopeChain {
         return stack.getFirst().containsKey(variableName);
     }
 
+    /**
+     * Sets the value of a variable in the first scope in the chain that
+     * already contains the variable; adds a variable to the current scope
+     * if an existing variable is not found.
+     *
+     * @param key   The name of the variable
+     * @param value The value of the variable
+     */
+    public void set(String key, Object value) {
+        /*
+         * The majority of time, the requested variable will be in the first
+         * scope so we do a quick lookup in that scope before attempting to
+         * create an iterator, etc. This is solely for performance.
+         */
+        Scope scope = stack.getFirst();
+        if (scope.containsKey(key)) {
+            scope.put(key, value);
+            return;
+        }
+
+        Iterator<Scope> iterator = stack.iterator();
+
+        // account for the first lookup we did
+        iterator.next();
+
+        while (iterator.hasNext()) {
+            scope = iterator.next();
+
+            if (scope.isLocal() || scope.containsKey(key)) {
+                scope.put(key, value);
+                return;
+            }
+        }
+
+        // no existing variable, create a new one
+        put(key, value);
+    }
 }

--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -821,6 +821,26 @@ public class CoreTagsTest extends AbstractTest {
     }
 
     @Test
+    public void testReSetInForLoop() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        String source = "{% set total = 0 %}{% for i in 1..1 %}{% for item in items %}{% set total = total + item.balance %}{% endfor %}{% endfor %}{{ total }}";
+        PebbleTemplate template = pebble.getTemplate(source);
+        Map<String, Object> context = new HashMap<>();
+        List<Map<String,Object>> items = new ArrayList<>();
+        for (int i = 1; i < 4 ; ++i) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("balance", i);
+            items.add(item);
+        }
+        context.put("items", items);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("6", writer.toString());
+    }
+
+    @Test
     public void testVerbatim() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
         PebbleTemplate template = pebble.getTemplate("{% verbatim %}{{ foo }}{{ bar }}{% endverbatim %}");

--- a/src/test/java/com/mitchellbosecke/pebble/ScopeChainTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ScopeChainTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * <p>
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * <p>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.ScopeChain;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScopeChainTest extends AbstractTest {
+
+    @Test
+    public void testSet() throws PebbleException, IOException {
+        ScopeChain scopeChain = new ScopeChain();
+        scopeChain.pushScope();
+        scopeChain.set("key", "value");
+        assertEquals("value", scopeChain.get("key"));
+        scopeChain.pushScope();
+        scopeChain.set("key", "value2");
+        assertEquals("value2", scopeChain.get("key"));
+        scopeChain.popScope();
+        assertEquals("value2", scopeChain.get("key"));
+    }
+}


### PR DESCRIPTION
This is a fix for issue #201, in which set tags inside nested for loops are undone at the end of the for loop.