### PR TITLE
Fix tests when run from a path containing spaces

### DIFF
--- a/src/test/java/com/mitchellbosecke/pebble/LoaderTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/LoaderTest.java
@@ -15,6 +15,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.junit.Test;
 
 import java.io.*;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -67,12 +68,12 @@ public class LoaderTest extends AbstractTest {
     }
 
     @Test
-    public void testFileLoader() throws PebbleException, IOException {
+    public void testFileLoader() throws PebbleException, IOException, URISyntaxException {
         Loader<?> loader = new FileLoader();
         loader.setSuffix(".suffix");
         PebbleEngine engine = new PebbleEngine.Builder().loader(loader).strictVariables(false).build();
         URL url = getClass().getResource("/templates/template.loaderTest.peb");
-        PebbleTemplate template1 = engine.getTemplate(url.getPath());
+        PebbleTemplate template1 = engine.getTemplate(new File(url.toURI()).getPath());
         Writer writer1 = new StringWriter();
         template1.evaluate(writer1);
         assertEquals("SUCCESS", writer1.toString());

--- a/src/test/java/com/mitchellbosecke/pebble/TestRelativePath.java
+++ b/src/test/java/com/mitchellbosecke/pebble/TestRelativePath.java
@@ -5,9 +5,11 @@ import com.mitchellbosecke.pebble.loader.FileLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
@@ -64,11 +66,11 @@ public class TestRelativePath extends AbstractTest {
      * Tests if relative includes work. Issue #162.
      */
     @Test
-    public void testPathWithBackslashesWithRelativePathWithForwardSlashes() throws PebbleException, IOException {
+    public void testPathWithBackslashesWithRelativePathWithForwardSlashes() throws PebbleException, IOException, URISyntaxException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new FileLoader()).build();
         URL url = getClass().getResource("/templates/relativepath/subdirectory1/template.forwardslashes.peb");
         PebbleTemplate template = pebble
-                .getTemplate(url.getPath().replace("/", "\\")); // ensure backslashes in all environments
+                .getTemplate(new File(url.toURI()).getPath().replace("/", "\\")); // ensure backslashes in all environments
         Writer writer = new StringWriter();
         template.evaluate(writer);
         assertEquals("included", writer.toString());
@@ -80,11 +82,11 @@ public class TestRelativePath extends AbstractTest {
      * @throws IOException
      */
     @Test
-    public void testPathWithForwardSlashesWithRelativePathWithBackwardSlashes() throws PebbleException, IOException {
+    public void testPathWithForwardSlashesWithRelativePathWithBackwardSlashes() throws PebbleException, IOException, URISyntaxException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new FileLoader()).build();
         URL url = getClass().getResource("/templates/relativepath/subdirectory1/template.backwardslashes.peb");
         PebbleTemplate template = pebble
-                .getTemplate(url.getPath().replace("\\", "/")); // ensure forward slashes in all environments
+                .getTemplate(new File(url.toURI()).getPath().replace("\\", "/")); // ensure forward slashes in all environments
         Writer writer = new StringWriter();
         template.evaluate(writer);
         assertEquals("included", writer.toString());


### PR DESCRIPTION
If the path containing the source code has spaces in it, then getResource
returns a URL with spaces replaced by %20, which, when treated as a file
name, fails to find anything.

The solution is to convert to a File object (via URI) as that process
takes care of decoding the %20 (and any other URL encoding that might
creep in).