### PR TITLE
Add tests for dynamic include and import

### DIFF
--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -733,6 +733,24 @@ public class CoreTagsTest extends AbstractTest {
         assertEquals("ajax macro" + LINE_SEPARATOR, writer.toString());
     }
 
+    @Test
+    public void testDynamicInclude() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().strictVariables(false).build();
+        PebbleTemplate template = pebble.getTemplate("templates/template.include.dynamic.peb");
+
+        Map<String, Object> context = new HashMap<>();
+
+        context.put("admin", false);
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("default footer", writer.toString());
+
+        context.put("admin", true);
+        writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("admin footer", writer.toString());
+    }
+
     @Test(expected = PebbleException.class)
     public void testNonExistingMacroOrFunction() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();

--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -714,6 +714,24 @@ public class CoreTagsTest extends AbstractTest {
         assertEquals("	<input name=\"company\" value=\"forcorp\" type=\"text\" />" + LINE_SEPARATOR,
                 writer.toString());
     }
+    
+    @Test
+    public void testDynamicImport() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().strictVariables(false).build();
+        PebbleTemplate template = pebble.getTemplate("templates/template.import.dynamic.peb");
+
+        Map<String, Object> context = new HashMap<>();
+
+        context.put("modern", false);
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("classic macro" + LINE_SEPARATOR, writer.toString());
+
+        context.put("modern", true);
+        writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("ajax macro" + LINE_SEPARATOR, writer.toString());
+    }
 
     @Test(expected = PebbleException.class)
     public void testNonExistingMacroOrFunction() throws PebbleException, IOException {

--- a/src/test/resources/templates/template.import.dynamic.macro_ajax.peb
+++ b/src/test/resources/templates/template.import.dynamic.macro_ajax.peb
@@ -1,0 +1,4 @@
+{# used by CoreTagsTest.testDynamicImport #}
+{% macro render_form() %}
+ajax macro
+{% endmacro %}

--- a/src/test/resources/templates/template.import.dynamic.macro_classic.peb
+++ b/src/test/resources/templates/template.import.dynamic.macro_classic.peb
@@ -1,0 +1,4 @@
+{# used by CoreTagsTest.testDynamicImport #}
+{% macro render_form() %}
+classic macro
+{% endmacro %}

--- a/src/test/resources/templates/template.import.dynamic.peb
+++ b/src/test/resources/templates/template.import.dynamic.peb
@@ -1,0 +1,6 @@
+{# used by CoreTagsTest.testDynamicImport #}
+{# depending on the boolean variable modern, different macro files will be #}
+{# imported. Both macro files provide a macro named render_form. #}
+{% import modern ? "templates/template.import.dynamic.macro_ajax.peb" 
+        : "templates/template.import.dynamic.macro_classic.peb" %}
+{{ render_form() }}

--- a/src/test/resources/templates/template.include.dynamic.adminFooter.peb
+++ b/src/test/resources/templates/template.include.dynamic.adminFooter.peb
@@ -1,0 +1,2 @@
+{# used by CoreTagsTest.testDynamicInclude #}
+admin footer

--- a/src/test/resources/templates/template.include.dynamic.defaultFooter.peb
+++ b/src/test/resources/templates/template.include.dynamic.defaultFooter.peb
@@ -1,0 +1,2 @@
+{# used by CoreTagsTest.testDynamicInclude #}
+default footer

--- a/src/test/resources/templates/template.include.dynamic.peb
+++ b/src/test/resources/templates/template.include.dynamic.peb
@@ -1,0 +1,4 @@
+{# used by CoreTagsTest.testDynamicInclude #}
+{# depending on the boolean variable admin, different templates will be included. #}
+{% include admin ? "templates/template.include.dynamic.adminFooter.peb" 
+        : "templates/template.include.dynamic.defaultFooter.peb" %}


### PR DESCRIPTION
This commit adds tests for the feature that one can use a dynamic expression to determine the template in the include- and import-tag.