### PR TITLE
Stop ScopeChain lookups when first scope is local

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
@@ -130,13 +130,10 @@ public class ScopeChain {
             // account for the first lookup we did
             iterator.next();
 
-            while (result == null && iterator.hasNext()) {
+            while (!scope.isLocal() && result == null && iterator.hasNext()) {
                 scope = iterator.next();
 
                 result = scope.get(key);
-                if (scope.isLocal()) {
-                    break;
-                }
             }
         }
 
@@ -168,14 +165,11 @@ public class ScopeChain {
         // account for the first lookup we did
         iterator.next();
 
-        while (iterator.hasNext()) {
+        while (!scope.isLocal() && iterator.hasNext()) {
             scope = iterator.next();
 
             if (scope.containsKey(key)) {
                 return true;
-            }
-            if (scope.isLocal()) {
-                break;
             }
         }
 

--- a/src/test/java/com/mitchellbosecke/pebble/ScopeChainTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ScopeChainTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ * <p>
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * <p>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.ScopeChain;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class ScopeChainTest extends AbstractTest {
+
+    @Test
+    public void testLocalScopeAtTop() throws PebbleException, IOException {
+        ScopeChain scopeChain = new ScopeChain();
+        scopeChain.pushScope();
+        scopeChain.put("key", "value");
+        assertEquals("value", scopeChain.get("key"));
+        scopeChain.pushLocalScope();
+        assertEquals(false, scopeChain.containsKey("key"));
+        assertNull(scopeChain.get("key"));
+        scopeChain.put("key", "value2");
+        assertEquals(true, scopeChain.containsKey("key"));
+        assertEquals("value2", scopeChain.get("key"));
+    }
+}


### PR DESCRIPTION
A local scope should stop the lookup from proceeding along the chain. This
was working in all cases except when the very first scope in the chain was
local.