### PR TITLE
Replacing Guava cache with the one from Caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,242 +1,255 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
 
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mitchellbosecke</groupId>
-	<artifactId>pebble</artifactId>
-	<version>2.2.4-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mitchellbosecke</groupId>
+    <artifactId>pebble</artifactId>
+    <version>2.2.4-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-	<name>Pebble</name>
-	<description>Templating engine for Java.</description>
-	<url>http://www.mitchellbosecke.com/pebble</url>
+    <name>Pebble</name>
+    <description>Templating engine for Java.</description>
+    <url>http://www.mitchellbosecke.com/pebble</url>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-	<licenses>
-		<license>
-			<name>BSD 3-Clause License</name>
-			<url>http://opensource.org/licenses/BSD-3-Clause</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>BSD 3-Clause License</name>
+            <url>http://opensource.org/licenses/BSD-3-Clause</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<name>Mitchell Bösecke</name>
-			<email>mitchellbosecke@gmail.com</email>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <name>Mitchell Bösecke</name>
+            <email>mitchellbosecke@gmail.com</email>
+        </developer>
+    </developers>
 
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.2.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
-				<configuration>
-					<outputDirectory>${project.build.directory}/javadoc</outputDirectory>
-					<reportOutputDirectory>${project.reporting.outputDirectory}/javadoc</reportOutputDirectory>
-					<excludes>
-						<exclude>**/*.txt</exclude>
-					</excludes>
-					<header>
-			            <![CDATA[
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
+                    <reportOutputDirectory>${project.reporting.outputDirectory}/javadoc</reportOutputDirectory>
+                    <excludes>
+                        <exclude>**/*.txt</exclude>
+                    </excludes>
+                    <header>
+                        <![CDATA[
 			                <a href="http://www.mitchellbosecke.com/pebble" target="_blank">Home</a>
 			            ]]>
-					</header>
-				</configuration>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>aggregate</id>
-						<goals>
-							<goal>aggregate</goal>
-						</goals>
-						<phase>site</phase>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<version>0.12</version>
-				<configuration>
-					<!-- <dryRun>true</dryRun> -->
-					<path>${project.version}</path>
-					<message>Creating site for ${project.version}</message>
-					<!-- sets the ~/.m2/setting.xml profile -->
-					<server>github</server>
-					<outputDirectory>${project.build.directory}/site/javadoc</outputDirectory>
-					<repositoryName>pebble</repositoryName>
-					<repositoryOwner>mbosecke</repositoryOwner>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>site</goal>
-						</goals>
-						<phase>site</phase>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<configuration>
-					<tagNameFormat>v@{project.version}</tagNameFormat>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                    </header>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>aggregate</id>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                        <phase>site</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.12</version>
+                <configuration>
+                    <!-- <dryRun>true</dryRun> -->
+                    <path>${project.version}</path>
+                    <message>Creating site for ${project.version}</message>
+                    <!-- sets the ~/.m2/setting.xml profile -->
+                    <server>github</server>
+                    <outputDirectory>${project.build.directory}/site/javadoc</outputDirectory>
+                    <repositoryName>pebble</repositoryName>
+                    <repositoryOwner>mbosecke</repositoryOwner>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>site</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-	<profiles>
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.4</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
-	<dependencies>
-	
-		<!-- required dependencies -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
-		</dependency>
-		<dependency>
-			<groupId>com.coverity.security</groupId>
-			<artifactId>coverity-escapers</artifactId>
-			<version>1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.21</version>
-			<scope>compile</scope>
-		</dependency>
-		
-		<!-- optional dependencies -->
-		<dependency>
+    <dependencies>
+
+        <!-- required dependencies -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.coverity.security</groupId>
+            <artifactId>coverity-escapers</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.21</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- optional dependencies -->
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>2.5</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-		
-		<!-- testing dependencies -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.15</version>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>com.sun.jdmk</groupId>
-					<artifactId>jmxtools</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jmx</groupId>
-					<artifactId>jmxri</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.jms</groupId>
-					<artifactId>jms</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 
-	<scm>
-		<connection>scm:git:git://github.com/mbosecke/pebble.git</connection>
-		<developerConnection>scm:git:git@github.com:mbosecke/pebble.git</developerConnection>
-		<url>http://github.com/mbosecke/pebble.git</url>
-		<tag>HEAD</tag>
-	</scm>
+        <!-- testing dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.21</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.jdmk</groupId>
+                    <artifactId>jmxtools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jmx</groupId>
+                    <artifactId>jmxri</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.jms</groupId>
+                    <artifactId>jms</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId> org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <scm>
+        <connection>scm:git:git://github.com/mbosecke/pebble.git</connection>
+        <developerConnection>scm:git:git@github.com:mbosecke/pebble.git</developerConnection>
+        <url>http://github.com/mbosecke/pebble.git</url>
+        <tag>HEAD</tag>
+    </scm>
 </project>

--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -8,11 +8,14 @@
  ******************************************************************************/
 package com.mitchellbosecke.pebble;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.mitchellbosecke.pebble.cache.BaseTagCacheKey;
 import com.mitchellbosecke.pebble.error.LoaderException;
+import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RuntimePebbleException;
 import com.mitchellbosecke.pebble.extension.Extension;
 import com.mitchellbosecke.pebble.extension.ExtensionRegistry;
 import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
@@ -38,9 +41,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
+
+import static java.util.Objects.isNull;
 
 /**
  * The main class used for compiling templates. The PebbleEngine is responsible
@@ -117,43 +121,53 @@ public class PebbleEngine {
         try {
             final Object cacheKey = this.loader.createCacheKey(templateName);
 
-            result = templateCache.get(cacheKey, new Callable<PebbleTemplate>() {
-
-                public PebbleTemplateImpl call() throws Exception {
-
-                    LexerImpl lexer = new LexerImpl(syntax, extensionRegistry.getUnaryOperators().values(),
-                            extensionRegistry.getBinaryOperators().values());
-                    Reader templateReader = self.retrieveReaderFromLoader(self.loader, cacheKey);
-                    TokenStream tokenStream = lexer.tokenize(templateReader, templateName);
-
-                    Parser parser = new ParserImpl(extensionRegistry.getUnaryOperators(),
-                            extensionRegistry.getBinaryOperators(), extensionRegistry.getTokenParsers());
-                    RootNode root = parser.parse(tokenStream);
-
-                    PebbleTemplateImpl instance = new PebbleTemplateImpl(self, root, templateName);
-
-                    for (NodeVisitorFactory visitorFactory : extensionRegistry.getNodeVisitors()) {
-                        visitorFactory.createVisitor(instance).visit(root);
+            if(isNull(templateCache)){
+                result = getPebbleTemplate(self, templateName, cacheKey);
+            }
+            else {
+                result = templateCache.get(cacheKey, k -> {
+                    try {
+                        return getPebbleTemplate(self, templateName, cacheKey);
+                    } catch (PebbleException e) {
+                        throw new RuntimePebbleException(e);
                     }
-
-                    return instance;
-                }
-            });
-        } catch (ExecutionException e) {
+                });
+            }
+        } catch (CompletionException e) {
             /*
-             * The execution exception is probably caused by a PebbleException
-             * being thrown in the above Callable. We will unravel it and throw
+             * The completion exception is probably caused by a PebbleException
+             * being thrown in the above function. We will unravel it and throw
              * the original PebbleException which is more helpful to the end
              * user.
              */
-            if (e.getCause() != null && e.getCause() instanceof PebbleException) {
-                throw (PebbleException) e.getCause();
+            if (e.getCause() != null && e.getCause() instanceof RuntimePebbleException) {
+                RuntimePebbleException runtimePebbleException = (RuntimePebbleException) e.getCause();
+                throw (PebbleException) runtimePebbleException.getCause();
             } else {
                 throw new PebbleException(e, String.format("An error occurred while compiling %s", templateName));
             }
         }
 
         return result;
+    }
+
+    private PebbleTemplate getPebbleTemplate(final PebbleEngine self, final String templateName, final Object cacheKey) throws LoaderException, ParserException {
+        LexerImpl lexer = new LexerImpl(syntax, extensionRegistry.getUnaryOperators().values(),
+                extensionRegistry.getBinaryOperators().values());
+        Reader templateReader = self.retrieveReaderFromLoader(self.loader, cacheKey);
+        TokenStream tokenStream = lexer.tokenize(templateReader, templateName);
+
+        Parser parser = new ParserImpl(extensionRegistry.getUnaryOperators(),
+                extensionRegistry.getBinaryOperators(), extensionRegistry.getTokenParsers());
+        RootNode root = parser.parse(tokenStream);
+
+        PebbleTemplateImpl instance = new PebbleTemplateImpl(self, root, templateName);
+
+        for (NodeVisitorFactory visitorFactory : extensionRegistry.getNodeVisitors()) {
+            visitorFactory.createVisitor(instance).visit(root);
+        }
+
+        return instance;
     }
 
     /**
@@ -458,15 +472,15 @@ public class PebbleEngine {
             if (cacheActive) {
                 // default caches
                 if (templateCache == null) {
-                    templateCache = CacheBuilder.newBuilder().maximumSize(200).build();
+                    templateCache = Caffeine.newBuilder().maximumSize(200).build();
                 }
 
                 if (tagCache == null) {
-                    tagCache = CacheBuilder.newBuilder().maximumSize(200).build();
+                    tagCache = Caffeine.newBuilder().maximumSize(200).build();
                 }
             } else {
-                templateCache = CacheBuilder.newBuilder().maximumSize(0).build();
-                tagCache = CacheBuilder.newBuilder().maximumSize(0).build();
+                templateCache = null;
+                tagCache = null;
             }
 
             return new PebbleEngine(loader, syntax, strictVariables, defaultLocale, tagCache, templateCache,

--- a/src/main/java/com/mitchellbosecke/pebble/error/RuntimePebbleException.java
+++ b/src/main/java/com/mitchellbosecke/pebble/error/RuntimePebbleException.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ ******************************************************************************/
+package com.mitchellbosecke.pebble.error;
+
+public class RuntimePebbleException extends RuntimeException {
+
+    public RuntimePebbleException(PebbleException e){
+        super(e);
+    }
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContext.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContext.java
@@ -8,7 +8,7 @@
  ******************************************************************************/
 package com.mitchellbosecke.pebble.template;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.mitchellbosecke.pebble.cache.BaseTagCacheKey;
 import com.mitchellbosecke.pebble.extension.ExtensionRegistry;
 

--- a/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ArraySyntaxTest.java
@@ -10,9 +10,12 @@ package com.mitchellbosecke.pebble;
 
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RuntimePebbleException;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -20,10 +23,15 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class ArraySyntaxTest extends AbstractTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testArraySyntax() throws PebbleException, IOException {
@@ -87,15 +95,18 @@ public class ArraySyntaxTest extends AbstractTest {
                 writer.toString());
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testIncompleteArraySyntax() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ [,] }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
     @SuppressWarnings("serial")
@@ -440,16 +451,21 @@ public class ArraySyntaxTest extends AbstractTest {
         assertEquals("[0, 1, 2, 3]", writer.toString());
     }
 
-    @Test(expected = PebbleException.class)
+    @Test
     public void testAdditionOverloading3() throws PebbleException, IOException {
-
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{% set arr = 1 + [0,1] %}{{ arr }}";
         PebbleTemplate template = pebble.getTemplate(source);
 
         Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+
+        thrown.expect(PebbleException.class);
+        thrown.expectMessage(startsWith("Could not perform addition"));
+
+        //Act + Assert
+        template.evaluate(writer, new HashMap<>());
     }
 
     @Test
@@ -478,16 +494,21 @@ public class ArraySyntaxTest extends AbstractTest {
         assertEquals("[1]", writer.toString());
     }
 
-    @Test(expected = PebbleException.class)
+    @Test
     public void testSubtractionOverloading3() throws PebbleException, IOException {
-
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{% set arr = 1 - [0,2] %}{{ arr }}";
         PebbleTemplate template = pebble.getTemplate(source);
 
         Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+
+        thrown.expect(PebbleException.class);
+        thrown.expectMessage(startsWith("Could not perform subtraction"));
+
+        //Act + Assert
+        template.evaluate(writer, new HashMap<>());
     }
 
     @Test

--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -11,6 +11,7 @@
 package com.mitchellbosecke.pebble;
 
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RuntimePebbleException;
 import com.mitchellbosecke.pebble.extension.InvocationCountingFunction;
 import com.mitchellbosecke.pebble.extension.TestingExtension;
 import com.mitchellbosecke.pebble.loader.StringLoader;
@@ -538,7 +539,7 @@ public class CoreTagsTest extends AbstractTest {
         assertEquals("true", writer.toString());
     }
 
-    @Test(expected = PebbleException.class)
+    @Test(expected = RuntimePebbleException.class)
     public void testCacheWithNoName() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 

--- a/src/test/java/com/mitchellbosecke/pebble/ErrorReportingTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/ErrorReportingTest.java
@@ -11,70 +11,82 @@ package com.mitchellbosecke.pebble;
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.error.RootAttributeNotFoundException;
+import com.mitchellbosecke.pebble.error.RuntimePebbleException;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.StringWriter;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.StringEndsWith.endsWith;
 
 public class ErrorReportingTest extends AbstractTest {
 
-    @Test(expected = ParserException.class)
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
     public void testLineNumberErrorReportingWithUnixNewlines() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
-        try {
-            @SuppressWarnings("unused")
-            PebbleTemplate template = pebble.getTemplate("test\n\n\ntest\ntest\ntest\n{% error %}\ntest");
-        } catch (ParserException ex) {
-            String message = ex.getMessage();
-            System.out.println(message.substring(message.length() - 3, message.length()));
-            assertEquals(":7)", message.substring(message.length() - 3, message.length()));
-            throw ex;
-        }
+
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectMessage(endsWith(":7)"));
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate("test\n\n\ntest\ntest\ntest\n{% error %}\ntest");
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testLineNumberErrorReportingWithWindowsNewlines() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
-        try {
-            @SuppressWarnings("unused")
-            PebbleTemplate template = pebble.getTemplate("test\r\n\r\ntest\r\ntest\r\ntest\r\n{% error %}\r\ntest");
-        } catch (ParserException ex) {
-            String message = ex.getMessage();
-            assertEquals(":6)", message.substring(message.length() - 3, message.length()));
-            throw ex;
-        }
+
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectMessage(endsWith(":6)"));
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate("test\r\n\r\ntest\r\ntest\r\ntest\r\n{% error %}\r\ntest");
     }
 
-    @Test(expected = PebbleException.class)
+    @Test
     public void testLineNumberErrorReportingDuringEvaluation() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().strictVariables(false).build();
-        try {
-            PebbleTemplate template = pebble.getTemplate("templates/template.errorReporting.peb");
-            template.evaluate(new StringWriter());
-        } catch (PebbleException ex) {
-            String message = ex.getMessage();
-            assertEquals(":8)", message.substring(message.length() - 3, message.length()));
-            throw ex;
-        }
+
+        PebbleTemplate template = pebble.getTemplate("templates/template.errorReporting.peb");
+
+        thrown.expect(PebbleException.class);
+        thrown.expectMessage(endsWith(":8)"));
+
+        //Act + Assert
+        template.evaluate(new StringWriter());
     }
 
-    @Test(expected = RootAttributeNotFoundException.class)
+    @Test
     public void testMissingRootPropertyInStrictMode() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().strictVariables(true).build();
-        try {
-            PebbleTemplate template = pebble.getTemplate("templates/template.errorReportingMissingRootProperty.peb");
-            template.evaluate(new StringWriter());
-        } catch (PebbleException ex) {
-            String message = ex.getMessage();
-            assertEquals("root", ((RootAttributeNotFoundException) ex).getAttributeName());
-            assertEquals(message,
-                    "Root attribute [root] does not exist or can not be accessed and strict variables is set to true. (templates/template.errorReportingMissingRootProperty.peb:2)");
-            throw ex;
-        }
+        PebbleTemplate template = pebble.getTemplate("templates/template.errorReportingMissingRootProperty.peb");
+
+        thrown.expect(allOf(
+                    instanceOf(RootAttributeNotFoundException.class),
+                    hasProperty("attributeName", is("root"))
+                )
+        );
+        thrown.expectMessage("Root attribute [root] does not exist or can not be accessed and strict variables is set to true. (templates/template.errorReportingMissingRootProperty.peb:2)");
+
+        //Act
+        template.evaluate(new StringWriter());
     }
 
 }

--- a/src/test/java/com/mitchellbosecke/pebble/MapSyntaxTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/MapSyntaxTest.java
@@ -10,10 +10,13 @@ package com.mitchellbosecke.pebble;
 
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RuntimePebbleException;
 import com.mitchellbosecke.pebble.extension.TestingExtension;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -21,10 +24,15 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MapSyntaxTest extends AbstractTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testMapSyntax() throws PebbleException, IOException {
@@ -89,59 +97,74 @@ public class MapSyntaxTest extends AbstractTest {
         assertEquals("{key1=value1, key2=value2, key3=value3, key4=value4, key5=value5}", writer.toString());
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testIncompleteMapSyntax() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ {,} }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testIncompleteMapSyntax2() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ {'key'} }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testIncompleteMapSyntax3() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ {'key':} }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testIncompleteMapSyntax4() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ {:'value'} }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testIncompleteMapSyntax5() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ {'key':'value',} }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
     @SuppressWarnings("serial")

--- a/src/test/java/com/mitchellbosecke/pebble/TernaryExpressionTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/TernaryExpressionTest.java
@@ -10,9 +10,12 @@ package com.mitchellbosecke.pebble;
 
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.error.RuntimePebbleException;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -20,151 +23,194 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 
 public class TernaryExpressionTest extends AbstractTest {
 
-    @Test(expected = ParserException.class)
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
     public void testTernaryFail1() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 'true' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail2() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? : 'true' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail3() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 'true' : }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail4() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? : }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail5() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? : ? 'true' : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail6() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? true ? 'true' : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail7() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? : false ? 'true' : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail8() throws PebbleException, IOException {
+        //arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 2 > 2 ? 'true' : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail9() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 2 > 2 ? : 'false' : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail10() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 2 > 2 ? : : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail11() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 'true' : 3 > 3 ? 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail12() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 'true' : 3 > 3 ? : 'false' }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
-    @Test(expected = ParserException.class)
+    @Test
     public void testTernaryFail13() throws PebbleException, IOException {
+        //Arrange
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 
         String source = "{{ 1 > 1 ? 'true' : 3 > 3 ? : }}";
-        PebbleTemplate template = pebble.getTemplate(source);
 
-        Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        thrown.expect(RuntimePebbleException.class);
+        thrown.expectCause(instanceOf(ParserException.class));
+
+        //Act + Assert
+        pebble.getTemplate(source);
     }
 
     @Test
@@ -175,7 +221,7 @@ public class TernaryExpressionTest extends AbstractTest {
         PebbleTemplate template = pebble.getTemplate(source);
 
         Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        template.evaluate(writer, new HashMap<>());
         assertEquals("true", writer.toString());
     }
 
@@ -187,7 +233,7 @@ public class TernaryExpressionTest extends AbstractTest {
         PebbleTemplate template = pebble.getTemplate(source);
 
         Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        template.evaluate(writer, new HashMap<>());
         assertEquals("false", writer.toString());
     }
 
@@ -199,7 +245,7 @@ public class TernaryExpressionTest extends AbstractTest {
         PebbleTemplate template = pebble.getTemplate(source);
 
         Writer writer = new StringWriter();
-        template.evaluate(writer, new HashMap<String, Object>());
+        template.evaluate(writer, new HashMap<>());
         assertEquals("c", writer.toString());
     }
 
@@ -209,7 +255,7 @@ public class TernaryExpressionTest extends AbstractTest {
 
         String source = "{{ ('a' == 'b' ? 2 + 2 : (val - 2 is not even ? true : false) ) ? (min(otherVal,-1) | abs <  3 / 3 - 1 ? false : ['yay!'] contains 'yay!' ) : ('?' is not empty ? ''~'?' : 0) }}";
         PebbleTemplate template = pebble.getTemplate(source);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("val", 3);
         params.put("otherVal", 100);
         Writer writer = new StringWriter();
@@ -223,7 +269,7 @@ public class TernaryExpressionTest extends AbstractTest {
 
         String source = "{{ 'a' == 'b' ? 2 + 2 : val - 2 is not even ? true : false ? min(otherVal,-1) | abs <  3 / 3 - 1 ? false : ['yay!'] contains 'yay!' : '?' is not empty ? ''~'?' : 0 }}";
         PebbleTemplate template = pebble.getTemplate(source);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("val", 3);
         params.put("otherVal", 100);
         Writer writer = new StringWriter();


### PR DESCRIPTION
I made the replacement of the cache, updated some dependencies' version and fixed the involved unit tests.

Instead of creating a cache with max size set to zero, I decided to set the cache to `null`. I believe it should be faster to not pass through the cache, since it would always creates a `CompletableFuture` to compute the value that we have to return.
