### PR TITLE
DynamicAttributeProvider

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
@@ -14,8 +14,7 @@ public interface DynamicAttributeProvider {
     public boolean canProvideDynamicAttribute(Object attributeName);
     
     /**
-     * Returns the attribute associated to the specified key
-     * or <code>null</code> if not found.
+     * Returns the attribute given the specified name and arguments.
      */
     public Object getDynamicAttribute(Object attributeName, Object[] argumentValues);
 

--- a/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
@@ -17,6 +17,6 @@ public interface DynamicAttributeProvider {
      * Returns the attribute associated to the specified key
      * or <code>null</code> if not found.
      */
-    public Object getDynamicAttribute(Object attributeName);
+    public Object getDynamicAttribute(Object attributeName, Object[] argumentValues);
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
@@ -1,0 +1,22 @@
+package com.mitchellbosecke.pebble.extension;
+
+/**
+ * When an object implements this interface, it tells
+ * the expression parser that it is able to provide
+ * dynamic attributes.
+ */
+public interface DynamicAttributeProvider {
+    
+    /**
+     * Returns <code>true</code> if the attribute can be
+     * provided given the specified name.
+     */
+    public boolean canProvideDynamicAttribute(Object attributeName);
+    
+    /**
+     * Returns the attribute associated to the specified key
+     * or <code>null</code> if not found.
+     */
+    public Object getDynamicAttribute(Object attributeName);
+
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/DynamicAttributeProvider.java
@@ -11,11 +11,11 @@ public interface DynamicAttributeProvider {
      * Returns <code>true</code> if the attribute can be
      * provided given the specified name.
      */
-    public boolean canProvideDynamicAttribute(Object attributeName);
+    boolean canProvideDynamicAttribute(Object attributeName);
     
     /**
      * Returns the attribute given the specified name and arguments.
      */
-    public Object getDynamicAttribute(Object attributeName, Object[] argumentValues);
+    Object getDynamicAttribute(Object attributeName, Object[] argumentValues);
 
 }

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -87,16 +87,6 @@ public class GetAttributeExpression implements Expression<Object> {
         Member member = object == null ? null : memberCache.get(new MemberCacheKey(object.getClass(), attributeName));
 
         if (object != null && member == null) {
-            
-            /**
-             * Check if the the object can provide the attribute
-             * in a dynamic way.
-             */
-            if(object instanceof DynamicAttributeProvider) {
-                if(((DynamicAttributeProvider)object).canProvideDynamicAttribute(attributeName)) {
-                    return ((DynamicAttributeProvider)object).getDynamicAttribute(attributeNameValue);
-                }   
-            }
 
             /*
              * If, and only if, no arguments were provided does it make sense to
@@ -167,6 +157,13 @@ public class GetAttributeExpression implements Expression<Object> {
                     argumentTypes[i] = null;
                 } else {
                     argumentTypes[i] = o.getClass();
+                }
+            }
+          
+            // check if the object is able to provide the attribute dynamically
+            if(object instanceof DynamicAttributeProvider) {
+                if(((DynamicAttributeProvider)object).canProvideDynamicAttribute(attributeName)) {
+                    return ((DynamicAttributeProvider)object).getDynamicAttribute(attributeNameValue, argumentValues);
                 }
             }
 

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -31,8 +31,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Used to get an attribute from an object. It will look up attributes in the
- * following order: {@link DynamicAttributeProvider}, map entry, array item, list item, 
- * get method, is method, has method, public method, public field.
+ * following order: map entry, array item, list item, 
+ * {@link DynamicAttributeProvider}, get method, is method, has method, public method, 
+ * public field.
  *
  * @author Mitchell
  */

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -11,6 +11,7 @@ package com.mitchellbosecke.pebble;
 import com.mitchellbosecke.pebble.error.AttributeNotFoundException;
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.error.RootAttributeNotFoundException;
+import com.mitchellbosecke.pebble.extension.DynamicAttributeProvider;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.junit.Test;
@@ -577,6 +578,40 @@ public class GetAttributeTest extends AbstractTest {
         public String getStringFromBoolean(boolean bool) {
             return String.valueOf(bool);
         }
+    }
+    
+    public class DynamicAttributeProviderObject implements DynamicAttributeProvider {
+
+        @Override
+        public boolean canProvideDynamicAttribute(Object attributeName) {
+            
+            if("name".equals(attributeName)) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Object getDynamicAttribute(Object attributeName) {
+            
+            if("name".equals(attributeName)) {
+                return "Steve";
+            }
+            return null;
+        }
+    }
+    
+    @Test
+    public void testAttributeProviderSimple() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).build();
+
+        PebbleTemplate template = pebble.getTemplate("hello {{ object.name }}");
+        Map<String, Object> context = new HashMap<>();
+        context.put("object", new DynamicAttributeProviderObject());
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello Steve", writer.toString());
     }
 
 }

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -592,7 +592,7 @@ public class GetAttributeTest extends AbstractTest {
         }
 
         @Override
-        public Object getDynamicAttribute(Object attributeName) {
+        public Object getDynamicAttribute(Object attributeName, Object[] argumentValues) {
             
             if("name".equals(attributeName)) {
                 return "Steve";
@@ -613,5 +613,9 @@ public class GetAttributeTest extends AbstractTest {
         template.evaluate(writer, context);
         assertEquals("hello Steve", writer.toString());
     }
+    
+    
+    
+    
 
 }


### PR DESCRIPTION
This is a feature I suggest and that would be really useful for me. It consists in a `DynamicAttributeProvider` interface which, when implemented by an object, tells the expression parser that this object is able to provide attributes _dynamically_, given their names and the potential arguments.

For example :

    public class MyObject implements DynamicAttributeProvider {

        @Override
        public boolean canProvideDynamicAttribute(Object attributeName) {
            
            if("firstname".equals(attributeName)) {
                return true;
            }
            return false;
        }

        @Override
        public Object getDynamicAttribute(Object attributeName, Object[] argumentValues) {
            
            if("firstname".equals(attributeName)) {
                return "John";
            }
            return null;
        }

        public String getSurname() {
            return "Doe";
        }
    }

Then `"{{ object.firstname }} {{ object.surname }}"` => **John Doe**

-------------------------

So, prior to check for :

- `getXXX `method
- `isXXX `method
- `hasXXX `method
- `XXX `method
- `XXX `field

the parser will call `DynamicAttributeProvider#canProvideDynamicAttribute(attributeName)` to see if the current object is able (and wants) to generate the attribute by itself. If so, the `DynamicAttributeProvider#getDynamicAttribute(attributeName, argumentValues)` method will be called.

This feature will help me since I do have a solution for issue #230 , but it involves adding a duplicate of all the `Map<String, Object>` parameters for the template to a special object and then add this object itself to the `Map`. With this feature, I wouln't have to duplicate anything.

Those changes shouldn't impact any existing code.