### PR TITLE
Removing break; from scope checking

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
@@ -135,7 +135,7 @@ public class ScopeChain {
 
                 result = scope.get(key);
                 if (scope.isLocal()) {
-                    break;
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
This particular line of code is causing issues - while rendering the
template we are finding that the second item in the stack of 6 is
marked as `isLocal`, and this is preventing the template from 
finding the item that is in the fourth item of the stack.

Maybe I am missing the point of this line of code - but it is
certainly causing an issue.