### PR TITLE
use templateName to load Reader, instead of cacheKey

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -123,7 +123,7 @@ public class PebbleEngine {
 
                     LexerImpl lexer = new LexerImpl(syntax, extensionRegistry.getUnaryOperators().values(),
                             extensionRegistry.getBinaryOperators().values());
-                    Reader templateReader = self.retrieveReaderFromLoader(self.loader, cacheKey);
+                    Reader templateReader = self.retrieveReaderFromLoader(self.loader, templateName);
                     TokenStream tokenStream = lexer.tokenize(templateReader, templateName);
 
                     Parser parser = new ParserImpl(extensionRegistry.getUnaryOperators(),
@@ -161,16 +161,12 @@ public class PebbleEngine {
      * to handle the generic cast.
      *
      * @param loader   the loader to use fetch the reader.
-     * @param cacheKey the cache key to use.
+     * @param templateName the template name to use.
      * @return the reader object.
      * @throws LoaderException thrown when the template could not be loaded.
      */
-    private <T> Reader retrieveReaderFromLoader(Loader<T> loader, Object cacheKey) throws LoaderException {
-        // We make sure within getTemplate() that we use only the same key for
-        // the same loader and hence we can be sure that the cast is safe.
-        @SuppressWarnings("unchecked")
-        T casted = (T) cacheKey;
-        return loader.getReader(casted);
+    private <T> Reader retrieveReaderFromLoader(Loader<T> loader, String templateName) throws LoaderException {
+        return loader.getReader(templateName);
     }
 
     /**

--- a/src/main/java/com/mitchellbosecke/pebble/loader/DelegatingLoader.java
+++ b/src/main/java/com/mitchellbosecke/pebble/loader/DelegatingLoader.java
@@ -53,16 +53,15 @@ public class DelegatingLoader implements Loader<DelegatingLoaderCacheKey> {
 
 
     @Override
-    public Reader getReader(DelegatingLoaderCacheKey cacheKey) throws LoaderException {
+    public Reader getReader(String templateName) throws LoaderException {
 
         Reader reader = null;
 
         final int size = this.loaders.size();
         for (int i = 0; i < size; i++) {
             Loader<?> loader = this.loaders.get(i);
-            Object delegatingKey = cacheKey.getDelegatingCacheKeys().get(i);
             try {
-                reader = this.getReaderInner(loader, delegatingKey);
+                reader = this.getReaderInner(loader, templateName);
                 if (reader != null) {
                     break;
                 }
@@ -71,21 +70,15 @@ public class DelegatingLoader implements Loader<DelegatingLoaderCacheKey> {
             }
         }
         if (reader == null) {
-            throw new LoaderException(null, "Could not find template \"" + cacheKey.getTemplateName() + "\"");
+            throw new LoaderException(null, "Could not find template \"" + templateName + "\"");
         }
 
         return reader;
     }
 
-    private <T> Reader getReaderInner(Loader<T> delegatingLoader, Object cacheKey)
+    private <T> Reader getReaderInner(Loader<T> delegatingLoader, String templateName)
             throws LoaderException {
-
-        // This unchecked cast is ok, because we ensure that the type of the
-        // cache key corresponds to the loader when we create the key.
-        @SuppressWarnings("unchecked")
-        T castedKey = (T) cacheKey;
-
-        return delegatingLoader.getReader(castedKey);
+        return delegatingLoader.getReader(templateName);
     }
 
     public String getSuffix() {

--- a/src/main/java/com/mitchellbosecke/pebble/loader/Loader.java
+++ b/src/main/java/com/mitchellbosecke/pebble/loader/Loader.java
@@ -27,13 +27,13 @@ public interface Loader<T> {
      * The reader which will be used by Pebble to read the contents of the
      * template.
      *
-     * @param cacheKey
-     *           the cache key to use to load create the reader.
+     * @param templateName
+     *           the template name to use to load create the reader.
      * @return A reader object
      * @throws LoaderException
      *             If template can not be found
      */
-    Reader getReader(T cacheKey) throws LoaderException;
+    Reader getReader(String templateName) throws LoaderException;
 
     /**
      * A method for end users to change the charset used by the loader.


### PR DESCRIPTION
consider this case,  some app has multi templates package for different sub domain, each package has same sub directory structure and same template name.  developer can implement Loader to  switch templates package. if enable cache,  there will be a problem， same templateName -> multi cacheKey

so, I think, 
cacheKey should be used to mapping template instance only. it should not be used to load reader.
 If necessary,  the loader which can invoke the createCacheKey method within Loader#getReader.
 