### PR TITLE
Handle all Iterables and Arrays in JoinFilter 

### DIFF
--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -564,6 +564,86 @@ public class CoreFiltersTest extends AbstractTest {
     }
 
     @Test
+    public void testJoinWithStringArray() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        PebbleTemplate template = pebble.getTemplate("{{ names | join(',') }}");
+
+        String[] names = new String[]{"Alex", "Joe", "Bob"};
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("names", names);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("Alex,Joe,Bob", writer.toString());
+    }
+
+    @Test
+    public void testJoinWithStringArrayWithoutGlue() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        PebbleTemplate template = pebble.getTemplate("{{ names | join }}");
+
+        String[] names = new String[]{"Alex", "Joe", "Bob"};
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("names", names);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("AlexJoeBob", writer.toString());
+    }
+
+    @Test
+    public void testJoinWithNumbersArray() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        PebbleTemplate template = pebble.getTemplate("{{ numbers | join(',') }}");
+
+        int[] numbers = new int[]{1,2,3};
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("numbers", numbers);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("1,2,3", writer.toString());
+    }
+
+    @Test
+    public void testJoinWithEmptyNumbersArray() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        PebbleTemplate template = pebble.getTemplate("{{ numbers | join(',') }}");
+
+        int[] numbers = new int[0];
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("numbers", numbers);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("", writer.toString());
+    }
+
+    @Test
+    public void testJoinWithFloatArray() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        PebbleTemplate template = pebble.getTemplate("{{ numbers | join(',') }}");
+
+        float[] numbers = new float[]{1.0f,2.5f,3.0f};
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("numbers", numbers);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("1.0,2.5,3.0", writer.toString());
+    }
+
+    @Test
     public void testLast() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 


### PR DESCRIPTION
JoinFilter is now able to join all all objects which are Iterable and all Arrays. Since Array is not an Iterable the implementation handles Object[] and arrays of primite data types specially.

This is useful if a backend class uses Arrays instead of Lists, for example. If JoinFilter did not support Arrays then either a conversion or a custom JoinFilter would be necessary.