### PR TITLE
Make "loop.length" and "loop.revindex" be lazy evaluated

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/ForNode.java
@@ -14,7 +14,6 @@ import com.mitchellbosecke.pebble.node.expression.Expression;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
 import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 import com.mitchellbosecke.pebble.template.ScopeChain;
-
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Array;
@@ -39,6 +38,12 @@ public class ForNode extends AbstractRenderableNode {
 
     private final BodyNode elseBody;
 
+    class Control extends Object {
+        protected int value = -1;
+        public Control(int value){ this.value = value; }
+        public Control() {}
+    }
+    
     public ForNode(int lineNumber, String variableName, Expression<?> iterableExpression, BodyNode body,
             BodyNode elseBody) {
         super(lineNumber);
@@ -51,9 +56,9 @@ public class ForNode extends AbstractRenderableNode {
     @Override
     public void render(PebbleTemplateImpl self, Writer writer, EvaluationContext context)
             throws PebbleException, IOException {
-        Object iterableEvaluation = this.iterableExpression.evaluate(self, context);
+        final Object iterableEvaluation = this.iterableExpression.evaluate(self, context);
         Iterable<?> iterable = null;
-
+        
         if (iterableEvaluation == null) {
             return;
         }
@@ -71,12 +76,21 @@ public class ForNode extends AbstractRenderableNode {
 
             ScopeChain scopeChain = context.getScopeChain();
             scopeChain.pushScope();
-
-            int length = this.getIteratorSize(iterableEvaluation);
+            
+            final Control length = new Control() {
+                @Override
+                public String toString() {
+                    if ( this.value == -1 )   {
+                        this.value = getIteratorSize(iterableEvaluation);
+                    }
+                    return String.valueOf(value);
+                }
+            };
+            
             int index = 0;
-
+            
             Map<String, Object> loop = null;
-
+            
             boolean usingExecutorService = context.getExecutorService() != null;
 
             while (iterator.hasNext()) {
@@ -90,27 +104,30 @@ public class ForNode extends AbstractRenderableNode {
                 if (index == 0 || usingExecutorService) {
                     loop = new HashMap<>();
                     loop.put("first", index == 0);
-                    loop.put("last", index == length - 1);
+                    loop.put("last", !iterator.hasNext());
                     loop.put("length", length);
-                }else{
-
+                } else if (index == 1) {
                     // second iteration
-                    if(index == 1){
-                        loop.put("first", false);
+                    loop.put("first", false);
+                }
+                
+                Control revindex = new Control(index) {
+                    @Override
+                    public String toString() {
+                        return String.valueOf( Integer.valueOf(length.toString()) - this.value -1);
                     }
+                };
+                
+                loop.put("revindex", revindex);
+                loop.put("index", index++);
+                scopeChain.put("loop", loop);
+                scopeChain.put(this.variableName, iterator.next());
 
-                    // last iteration
-                    if(index == length - 1){
-                        loop.put("last", true);
-                    }
+                // last iteration
+                if( !iterator.hasNext() ){
+                    loop.put("last", true);
                 }
 
-                loop.put("revindex", length - index - 1);
-                loop.put("index", index++);
-
-                scopeChain.put("loop", loop);
-
-                scopeChain.put(this.variableName, iterator.next());
                 this.body.render(self, writer, context);
             }
 

--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -239,6 +239,11 @@ public class CoreTagsTest extends AbstractTest {
                     public User next() {
                         return fixture[pos++];
                     }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                    }
                 };
             }
         };

--- a/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreTagsTest.java
@@ -15,16 +15,14 @@ import com.mitchellbosecke.pebble.extension.InvocationCountingFunction;
 import com.mitchellbosecke.pebble.extension.TestingExtension;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.*;
 import java.util.concurrent.Executors;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import org.junit.Test;
 
 public class CoreTagsTest extends AbstractTest {
 
@@ -218,6 +216,42 @@ public class CoreTagsTest extends AbstractTest {
         assertEquals("[3]02Alex11Bob[3]20John", writer.toString());
     }
 
+    @Test
+    public void testForWithIterable() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        String source = "{% for user in users %}{% if loop.first %}[first]{% endif %}{% if loop.last %}[last]{% endif %}{{ loop.index }}{{ user.username }}{% endfor %}";
+        PebbleTemplate template = pebble.getTemplate(source);
+        Iterable<User> users = new Iterable<User>() {
+            @Override
+            public Iterator<User> iterator() {
+                return new Iterator<User>() {
+                    
+                    User[] fixture = new User[]{ new User("Alex"), new User("Bob"), new User("John") };
+                    int pos = 0;
+                    
+                    @Override
+                    public boolean hasNext() {
+                        return pos < fixture.length;
+                    }
+
+                    @Override
+                    public User next() {
+                        return fixture[pos++];
+                    }
+                };
+            }
+        };
+        
+        Map<String, Object> context = new HashMap<>();        
+        context.put("users", users);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("[first]0Alex1Bob[last]2John", writer.toString());
+    }
+    
+    
     @Test
     public void testForWithMap() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();


### PR DESCRIPTION
Make "_loop.length_" and "_loop.revindex_" be lazy evaluated, getting its value only if exists in 'for' template block.

This implementation is useful when used with Iterable object.

> "For performance reasons, the use of 'loop.length' or 'loop.revindex' in templates with Iterable object could slow down the iteration in 'for' tag."
> (Iterable haven't size() or lenght() methods, so to get its length is necessary to count until the end of 'iterator.next()' )