### PR TITLE
Implement SafeString.hashCode()

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/escaper/SafeString.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/escaper/SafeString.java
@@ -24,4 +24,9 @@ public class SafeString {
 	public boolean equals(Object o) {
 		return o instanceof SafeString && this.content.equals(((SafeString) o).content);
 	}
+
+	@Override
+	public int hashCode() {
+		return (content == null) ? 0 : content.hashCode();
+	}
 }


### PR DESCRIPTION
`SafeString` had `equals()` defined but not `hashCode()`, this violates the contract required for these methods, and as such, would result in undefined behaviour if `SafeString` objects were used in a hashing data structure.

This problem was found on [lgtm.com](https://lgtm.com), and there are a number of other alerts that it's found: https://lgtm.com/projects/g/PebbleTemplates/pebble/alerts/

If you're interested, you can also set up pull request integration for free to catch the introduction of new alerts: https://lgtm.com/projects/g/PebbleTemplates/pebble/ci/

*Full Disclosure: I'm a core developer at lgtm.com, and we actually use pebble for the administration panel for the enterprise version of lgtm.*