### PR TITLE
remove unused extensions map in ExtensionRegistry

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/ExtensionRegistry.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/ExtensionRegistry.java
@@ -15,11 +15,6 @@ import java.util.*;
 public class ExtensionRegistry {
 
     /**
-     * Extensions
-     */
-    private HashMap<Class<? extends Extension>, Extension> extensions = new HashMap<>();
-
-    /**
      * Unary operators used during the lexing phase.
      */
     private Map<String, UnaryOperator> unaryOperators = new HashMap<>();
@@ -62,8 +57,6 @@ public class ExtensionRegistry {
     public ExtensionRegistry(Collection<? extends Extension> extensions) {
 
         for (Extension extension : extensions) {
-            this.extensions.put(extension.getClass(), extension);
-
             // token parsers
             List<TokenParser> tokenParsers = extension.getTokenParsers();
             if (tokenParsers != null) {
@@ -155,17 +148,4 @@ public class ExtensionRegistry {
     public Map<String, TokenParser> getTokenParsers() {
         return this.tokenParsers;
     }
-
-    /*
-    @SuppressWarnings("unchecked")
-    public <T extends Extension> T getExtension(Class<T> clazz) {
-        return (T) this.extensions.get(clazz);
-    }
-
-
-
-    public HashMap<Class<? extends Extension>, Extension> getExtensions() {
-        return extensions;
-    }
-    */
 }


### PR DESCRIPTION
The access methods for this property had been commented out, and are unused, but the contents of the map were still being maintained (unnecessarily).

This problem was found on [lgtm.com](https://lgtm.com), and there are a number of other alerts that it's found: https://lgtm.com/projects/g/PebbleTemplates/pebble/alerts/

If you're interested, you can also set up pull request integration for free to catch the introduction of new alerts: https://lgtm.com/projects/g/PebbleTemplates/pebble/ci/

*Full Disclosure: I'm a core developer at lgtm.com, and we actually use pebble for the administration panel for the enterprise version of lgtm.*