### PR TITLE
Fix NPE in GetAttributeExpression

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -208,7 +208,7 @@ public class GetAttributeExpression implements Expression<Object> {
         if (object.isEmpty()) {
             return null;
         }
-        if (Number.class.isAssignableFrom(attributeNameValue.getClass())) {
+        if (attributeNameValue != null && Number.class.isAssignableFrom(attributeNameValue.getClass())) {
             Number keyAsNumber = (Number) attributeNameValue;
 
             Class<?> keyClass = object.keySet().iterator().next().getClass();

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -85,6 +85,20 @@ public class GetAttributeTest extends AbstractTest {
     }
 
     @Test
+    public void testHashmapAttributeWithArgumentOfNull() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).build();
+        PebbleTemplate template = pebble.getTemplate("hello {{ object[missingContextProperty] }}");
+        Map<String, Object> context = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
+        map.put("name", "Steve");
+        context.put("object", map);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello ", writer.toString());
+    }
+
+    @Test
     public void testMethodAttribute() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).build();
 
@@ -553,7 +567,7 @@ public class GetAttributeTest extends AbstractTest {
 
         assertEquals("1 1 2 true", writer.toString());
     }
-    
+
     @Test
     public void testBeanMethodWithNullArgument() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).build();


### PR DESCRIPTION
The recent change to allow map access via primitives introduced an NPE situtation when null was being passed as the map key.  This PR fixes that issue by skipping `Number.class.isAssignableFrom` if the attributeNameValue is null