### PR TITLE
Add Reverse as a default filter

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/CoreExtension.java
@@ -92,6 +92,7 @@ public class CoreExtension extends AbstractExtension {
         filters.put("slice", new SliceFilter());
         filters.put("sort", new SortFilter());
         filters.put("rsort", new RsortFilter());
+        filters.put("reverse", new ReverseFilter());
         filters.put("title", new TitleFilter());
         filters.put("trim", new TrimFilter());
         filters.put("upper", new UpperFilter());

--- a/src/main/java/com/mitchellbosecke/pebble/extension/core/ReverseFilter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/core/ReverseFilter.java
@@ -1,0 +1,30 @@
+package com.mitchellbosecke.pebble.extension.core;
+import com.mitchellbosecke.pebble.extension.Filter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Revert the order of an input list
+ *
+ * @author Andrea La Scola
+ */
+public class ReverseFilter implements Filter {
+
+    @Override
+    public List<String> getArgumentNames() {
+        return null;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public List apply(Object input, Map<String, Object> args) {
+        if (input == null) {
+            return null;
+        }
+        List collection = (List) input;
+        Collections.reverse(collection);
+        return collection;
+    }
+}

--- a/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/CoreFiltersTest.java
@@ -356,6 +356,23 @@ public class CoreFiltersTest extends AbstractTest {
     }
 
     @Test
+    public void testReverseFilter() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        PebbleTemplate template = pebble.getTemplate("{% for word in words|reverse %}{{ word }} {% endfor %}");
+        List<String> words = new ArrayList<>();
+        words.add("one");
+        words.add("two");
+        words.add("three");
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("words", words);
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("three two one ", writer.toString());
+    }
+
+    @Test
     public void testTitle() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
 


### PR DESCRIPTION
Added "reverse" as a default filter.
This filter reverses the order of a list received in input without applying any sorting algorithm.

example usage:

```html
{% for word in words | reverse %} {{ word }} {% endfor %}
```

## Todos
- [X] Tests
- [x] Documentation


