### PR TITLE
Handle DynamicAttributeProvider with a lower priority than Maps and Arrays, see #293

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -90,14 +90,6 @@ public class GetAttributeExpression implements Expression<Object> {
 
         Object[] argumentValues = this.getArgumentValues(self, context);
 
-        // check if the object is able to provide the attribute dynamically
-        if(object != null && object instanceof DynamicAttributeProvider) {
-            DynamicAttributeProvider dynamicAttributeProvider = (DynamicAttributeProvider) object;
-            if(dynamicAttributeProvider.canProvideDynamicAttribute(attributeName)) {
-                return dynamicAttributeProvider.getDynamicAttribute(attributeNameValue, argumentValues);
-            }
-        }
-
         Member member = object == null ? null : this.memberCache.get(new MemberCacheKey(object.getClass(), attributeName));
         if (object != null && member == null) {
 
@@ -155,6 +147,14 @@ public class GetAttributeExpression implements Expression<Object> {
                     // do nothing
                 }
 
+            }
+
+            // check if the object is able to provide the attribute dynamically
+            if(object instanceof DynamicAttributeProvider) {
+                DynamicAttributeProvider dynamicAttributeProvider = (DynamicAttributeProvider) object;
+                if(dynamicAttributeProvider.canProvideDynamicAttribute(attributeName)) {
+                    return dynamicAttributeProvider.getDynamicAttribute(attributeNameValue, argumentValues);
+                }
             }
 
             /*


### PR DESCRIPTION
Motivation:

#241 introduced `DynamicAttributeProvider`. Type checking in
`GetAttributeExpression` seems to be pretty expensive, so as
`DynamicAttributeProvider` is not commonly used, Maps and Arrays
branches should have higher priority.

Modification:

Move the `DynamicAttributeProvider` branch down.

Result:

+10% throughput