### PR TITLE
Makes logic with allowGetClass and strictVariables well-defined

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -173,7 +173,7 @@ public class GetAttributeExpression implements Expression<Object> {
                 }
             }
 
-            member = this.reflect(object, attributeName, argumentTypes, context.isAllowGetClass());
+            member = this.reflect(object, attributeName, argumentTypes, context.isAllowGetClass(), context.isStrictVariables());
             if (member != null) {
                 this.memberCache.put(new MemberCacheKey(object.getClass(), attributeName), member);
             }
@@ -299,7 +299,7 @@ public class GetAttributeExpression implements Expression<Object> {
      * @param parameterTypes
      * @return
      */
-    private Member reflect(Object object, String attributeName, Class<?>[] parameterTypes, boolean allowGetClass) {
+    private Member reflect(Object object, String attributeName, Class<?>[] parameterTypes, boolean allowGetClass, boolean strictVariables) {
 
         Class<?> clazz = object.getClass();
 
@@ -309,21 +309,21 @@ public class GetAttributeExpression implements Expression<Object> {
         String attributeCapitalized = Character.toUpperCase(attributeName.charAt(0)) + attributeName.substring(1);
 
         // check get method
-        result = this.findMethod(clazz, "get" + attributeCapitalized, parameterTypes, allowGetClass);
+        result = this.findMethod(clazz, "get" + attributeCapitalized, parameterTypes, allowGetClass, strictVariables);
 
         // check is method
         if (result == null) {
-            result = this.findMethod(clazz, "is" + attributeCapitalized, parameterTypes, allowGetClass);
+            result = this.findMethod(clazz, "is" + attributeCapitalized, parameterTypes, allowGetClass, strictVariables);
         }
 
         // check has method
         if (result == null) {
-            result = this.findMethod(clazz, "has" + attributeCapitalized, parameterTypes, allowGetClass);
+            result = this.findMethod(clazz, "has" + attributeCapitalized, parameterTypes, allowGetClass, strictVariables);
         }
 
         // check if attribute is a public method
         if (result == null) {
-            result = this.findMethod(clazz, attributeName, parameterTypes, allowGetClass);
+            result = this.findMethod(clazz, attributeName, parameterTypes, allowGetClass, strictVariables);
         }
 
         // public field
@@ -350,12 +350,16 @@ public class GetAttributeExpression implements Expression<Object> {
      * @param requiredTypes
      * @return
      */
-    private Method findMethod(Class<?> clazz, String name, Class<?>[] requiredTypes, boolean allowGetClass) {
+    private Method findMethod(Class<?> clazz, String name, Class<?>[] requiredTypes, boolean allowGetClass, boolean strictVariables) {
         if (name.equals("getClass")) {
             if (!allowGetClass) {
-                throw new ClassAccessException(this.lineNumber, this.filename);
+                if(strictVariables) {
+                    throw new ClassAccessException(this.lineNumber, this.filename);
+                }
+                else {
+                    return null;
+                }
             }
-            return null;
         }
 
         Method result = null;

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -196,13 +196,9 @@ public class GetAttributeExpression implements Expression<Object> {
                 }
 
             } else {
-                if (attributeName.equals("class") || attributeName.equals("getClass")) {
-                    throw new ClassAccessException(this.lineNumber, this.filename);
-                } else {
-                    throw new AttributeNotFoundException(null, String.format(
-                            "Attribute [%s] of [%s] does not exist or can not be accessed and strict variables is set to true.",
-                            attributeName, object.getClass().getName()), attributeName, this.lineNumber, this.filename);
-                }
+                throw new AttributeNotFoundException(null, String.format(
+                        "Attribute [%s] of [%s] does not exist or can not be accessed and strict variables is set to true.",
+                        attributeName, object.getClass().getName()), attributeName, this.lineNumber, this.filename);
             }
         }
         return result;
@@ -351,10 +347,8 @@ public class GetAttributeExpression implements Expression<Object> {
      * @return
      */
     private Method findMethod(Class<?> clazz, String name, Class<?>[] requiredTypes, boolean allowGetClass) {
-        if (name.equals("getClass")) {
-            if (!allowGetClass) {
-                throw new ClassAccessException(this.lineNumber, this.filename);
-            }
+        if (!allowGetClass && name.equals("getClass")) {
+            throw new ClassAccessException(this.lineNumber, this.filename);
         }
 
         Method result = null;

--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -173,7 +173,7 @@ public class GetAttributeExpression implements Expression<Object> {
                 }
             }
 
-            member = this.reflect(object, attributeName, argumentTypes, context.isAllowGetClass(), context.isStrictVariables());
+            member = this.reflect(object, attributeName, argumentTypes, context.isAllowGetClass());
             if (member != null) {
                 this.memberCache.put(new MemberCacheKey(object.getClass(), attributeName), member);
             }
@@ -299,7 +299,7 @@ public class GetAttributeExpression implements Expression<Object> {
      * @param parameterTypes
      * @return
      */
-    private Member reflect(Object object, String attributeName, Class<?>[] parameterTypes, boolean allowGetClass, boolean strictVariables) {
+    private Member reflect(Object object, String attributeName, Class<?>[] parameterTypes, boolean allowGetClass) {
 
         Class<?> clazz = object.getClass();
 
@@ -309,21 +309,21 @@ public class GetAttributeExpression implements Expression<Object> {
         String attributeCapitalized = Character.toUpperCase(attributeName.charAt(0)) + attributeName.substring(1);
 
         // check get method
-        result = this.findMethod(clazz, "get" + attributeCapitalized, parameterTypes, allowGetClass, strictVariables);
+        result = this.findMethod(clazz, "get" + attributeCapitalized, parameterTypes, allowGetClass);
 
         // check is method
         if (result == null) {
-            result = this.findMethod(clazz, "is" + attributeCapitalized, parameterTypes, allowGetClass, strictVariables);
+            result = this.findMethod(clazz, "is" + attributeCapitalized, parameterTypes, allowGetClass);
         }
 
         // check has method
         if (result == null) {
-            result = this.findMethod(clazz, "has" + attributeCapitalized, parameterTypes, allowGetClass, strictVariables);
+            result = this.findMethod(clazz, "has" + attributeCapitalized, parameterTypes, allowGetClass);
         }
 
         // check if attribute is a public method
         if (result == null) {
-            result = this.findMethod(clazz, attributeName, parameterTypes, allowGetClass, strictVariables);
+            result = this.findMethod(clazz, attributeName, parameterTypes, allowGetClass);
         }
 
         // public field
@@ -350,15 +350,10 @@ public class GetAttributeExpression implements Expression<Object> {
      * @param requiredTypes
      * @return
      */
-    private Method findMethod(Class<?> clazz, String name, Class<?>[] requiredTypes, boolean allowGetClass, boolean strictVariables) {
+    private Method findMethod(Class<?> clazz, String name, Class<?>[] requiredTypes, boolean allowGetClass) {
         if (name.equals("getClass")) {
             if (!allowGetClass) {
-                if(strictVariables) {
-                    throw new ClassAccessException(this.lineNumber, this.filename);
-                }
-                else {
-                    return null;
-                }
+                throw new ClassAccessException(this.lineNumber, this.filename);
             }
         }
 

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -15,7 +15,6 @@ import com.mitchellbosecke.pebble.error.RootAttributeNotFoundException;
 import com.mitchellbosecke.pebble.extension.DynamicAttributeProvider;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
-
 import org.junit.Test;
 
 import java.io.IOException;
@@ -112,77 +111,145 @@ public class GetAttributeTest extends AbstractTest {
         assertEquals("hello Steve", writer.toString());
     }
 
+    /**
+     * Make sure we are properly accounting for getting the class object from an Object in all situations:
+     *
+     * | AllowGetClass | Strict Variables | Access Type | Result  |
+     * | ------------- | ---------------- | ----------- | ------- |
+     * | true          | false            | property    | allowed |
+     * | true          | false            | method      | allowed |
+     * | true          | true             | property    | allowed |
+     * | true          | true             | method      | allowed |
+     * | false         | false            | property    | null    |
+     * | false         | false            | method      | null    |
+     * | false         | true             | property    | throw   |
+     * | false         | true             | method      | throw   |
+     *
+     * @throws PebbleException
+     * @throws IOException
+     */
+
     @Test
-    public void testMethodAttributeWhenAccessingClassWithStrictVariableOffAndAllowGetClass() throws PebbleException, IOException {
+    public void testAccessingClass_AllowGetClassOn_StrictVariableOff_Property() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
-                .strictVariables(false)
                 .allowGetClass(true)
+                .strictVariables(false)
                 .build();
 
-        PebbleTemplate template = pebble.getTemplate("hello {{ object.class }}");
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.class }}]");
         Map<String, Object> context = new HashMap<>();
-        context.put("object", "some string");
+        context.put("object", new SimpleObject());
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
-        assertEquals("hello ", writer.toString());
+        assertEquals("hello [" + SimpleObject.class.toString() + "]", writer.toString());
     }
 
-    @Test(expected = ClassAccessException.class)
-    public void testMethodAttributeWhenAccessingClassWithStrictVariableOnAndAllowGetClass() throws PebbleException, IOException {
+    @Test
+    public void testAccessingClass_AllowGetClassOn_StrictVariableOff_Method() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+                .allowGetClass(true)
+                .strictVariables(false)
+                .build();
+
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.getClass() }}]");
+        Map<String, Object> context = new HashMap<>();
+        context.put("object", new SimpleObject());
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello [" + SimpleObject.class.toString() + "]", writer.toString());
+    }
+
+    @Test
+    public void testAccessingClass_AllowGetClassOn_StrictVariableOn_Property() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+                .allowGetClass(true)
                 .strictVariables(true)
-                .allowGetClass(true)
                 .build();
 
-        PebbleTemplate template = pebble.getTemplate("hello {{ object.class }}");
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.class }}]");
         Map<String, Object> context = new HashMap<>();
-        context.put("object", "some string");
+        context.put("object", new SimpleObject());
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
+        assertEquals("hello [" + SimpleObject.class.toString() + "]", writer.toString());
     }
 
-    @Test(expected = ClassAccessException.class)
-    public void testMethodAttributeWhenAccessingGetClassWithStrictVariableOnAndAllowGetClass() throws PebbleException, IOException {
+    @Test
+    public void testAccessingClass_AllowGetClassOn_StrictVariableOn_Method() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+                .allowGetClass(true)
                 .strictVariables(true)
-                .allowGetClass(true)
                 .build();
 
-        PebbleTemplate template = pebble.getTemplate("hello {{ object.getClass }}");
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.getClass() }}]");
         Map<String, Object> context = new HashMap<>();
-        context.put("object", "some string");
+        context.put("object", new SimpleObject());
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello [" + SimpleObject.class.toString() + "]", writer.toString());
+    }
+
+    @Test
+    public void testAccessingClass_AllowGetClassOff_StrictVariableOff_Property() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+                .allowGetClass(false)
+                .strictVariables(false)
+                .build();
+
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.class }}]");
+        Map<String, Object> context = new HashMap<>();
+        context.put("object", new SimpleObject());
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello []", writer.toString());
+    }
+
+    @Test
+    public void testAccessingClass_AllowGetClassOff_StrictVariableOff_Method() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+                .allowGetClass(false)
+                .strictVariables(false)
+                .build();
+
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.getClass() }}]");
+        Map<String, Object> context = new HashMap<>();
+        context.put("object", new SimpleObject());
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("hello []", writer.toString());
+    }
+
+    @Test(expected = ClassAccessException.class)
+    public void testAccessingClass_AllowGetClassOff_StrictVariableOn_Property() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+                .allowGetClass(false)
+                .strictVariables(true)
+                .build();
+
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.class }}]");
+        Map<String, Object> context = new HashMap<>();
+        context.put("object", new SimpleObject());
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
     }
 
     @Test(expected = ClassAccessException.class)
-    public void testMethodAttributeWhenAccessingClassWithStrictVariableOffAndDontAllowGetClass() throws PebbleException, IOException {
+    public void testAccessingClass_AllowGetClassOff_StrictVariableOn_Method() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
-                .strictVariables(false)
                 .allowGetClass(false)
+                .strictVariables(true)
                 .build();
 
-        PebbleTemplate template = pebble.getTemplate("hello {{ object.class }}");
+        PebbleTemplate template = pebble.getTemplate("hello [{{ object.getClass() }}]");
         Map<String, Object> context = new HashMap<>();
-        context.put("object", "some string");
-
-        Writer writer = new StringWriter();
-        template.evaluate(writer, context);
-    }
-
-    @Test(expected = ClassAccessException.class)
-    public void testMethodAttributeWhenAccessingGetClassWithStrictVariableOffAndDontAllowGetClass() throws PebbleException, IOException {
-        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
-                .strictVariables(false)
-                .allowGetClass(false)
-                .build();
-
-        PebbleTemplate template = pebble.getTemplate("hello {{ object.getClass }}");
-        Map<String, Object> context = new HashMap<>();
-        context.put("object", "some string");
+        context.put("object", new SimpleObject());
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -120,8 +120,8 @@ public class GetAttributeTest extends AbstractTest {
      * | true          | false            | method      | allowed |
      * | true          | true             | property    | allowed |
      * | true          | true             | method      | allowed |
-     * | false         | false            | property    | null    |
-     * | false         | false            | method      | null    |
+     * | false         | false            | property    | throw   |
+     * | false         | false            | method      | throw   |
      * | false         | true             | property    | throw   |
      * | false         | true             | method      | throw   |
      *
@@ -193,7 +193,7 @@ public class GetAttributeTest extends AbstractTest {
         assertEquals("hello [" + SimpleObject.class.toString() + "]", writer.toString());
     }
 
-    @Test
+    @Test(expected = ClassAccessException.class)
     public void testAccessingClass_AllowGetClassOff_StrictVariableOff_Property() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
                 .allowGetClass(false)
@@ -206,10 +206,9 @@ public class GetAttributeTest extends AbstractTest {
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
-        assertEquals("hello []", writer.toString());
     }
 
-    @Test
+    @Test(expected = ClassAccessException.class)
     public void testAccessingClass_AllowGetClassOff_StrictVariableOff_Method() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
                 .allowGetClass(false)
@@ -222,7 +221,6 @@ public class GetAttributeTest extends AbstractTest {
 
         Writer writer = new StringWriter();
         template.evaluate(writer, context);
-        assertEquals("hello []", writer.toString());
     }
 
     @Test(expected = ClassAccessException.class)


### PR DESCRIPTION
`allowGetClass` flag was always returning null or throwing ClassAccessException, even when it should have been allowed. This PR fixes that bug, and tests that it conforms to the following truth table (with the prior results also shown):

| AllowGetClass | Strict Variables | Access Type | Expected Result | Prior Result |
| ------------- | ---------------- | ----------- | --------------- | ------------ |
| true          | false            | property    | allowed         | null         |
| true          | false            | method      | allowed         | null         |
| true          | true             | property    | allowed         | throw        |
| true          | true             | method      | allowed         | throw        |
| false         | false            | property    | null            | throw        |
| false         | false            | method      | null            | throw        |
| false         | true             | property    | throw           | throw        |
| false         | true             | method      | throw           | throw        |

