### PR TITLE
Optimize ScopeChain for basic case with single scope

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
+++ b/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
@@ -112,19 +112,28 @@ public class ScopeChain {
          * null values must not be handled as "not present".
          */
         Scope scope = this.stack.getFirst();
-        if (scope.containsKey(key)) {
-            return scope.get(key);
+        Object result = scope.get(key);
+        if (result != null) {
+            return result;
         }
 
-        Iterator<Scope> iterator = this.stack.iterator();
-        // account for the first lookup we did
-        iterator.next();
-
-        while (iterator.hasNext()) {
-            scope = iterator.next();
-
+        if (this.stack.size() > 1) {
             if (scope.containsKey(key)) {
-                return scope.get(key);
+                // key could be defined with null and override another value below in the stack
+                return null;
+            }
+            Iterator<Scope> iterator = this.stack.iterator();
+            // account for the first lookup we did
+            iterator.next();
+
+            while (iterator.hasNext()) {
+                result = iterator.next().get(key);
+                if (result != null) {
+                    return result;
+                } else if (scope.containsKey(key)) {
+                    // null value
+                    return null;
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

`ScopeChain#get` performs `containsKey` then `get` so it can account for null values.

The current implementation tries to optimize for the single scope case for the chain scanning with saving an Iterator.
It's possible to go further this way.

Modification:

Optimize for the most common use case where the key is defined and there's a single scope.
Only perform a `get` and only check `contains` if the value is null and there is more than one scope.

Result:

Better performance.