### PR TITLE
PebbleEngine#getTemplate leaks file descriptor

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
+++ b/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java
@@ -37,6 +37,7 @@ import com.mitchellbosecke.pebble.template.EvaluationOptions;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -145,11 +146,18 @@ public class PebbleEngine {
 
       Object cacheKey = loader.createCacheKey(templateName);
       Reader templateReader = loader.getReader(cacheKey);
-      if (isNull(this.templateCache)) {
-        result = this.getPebbleTemplate(this, templateName, templateReader);
-      }
-      else {
-        result = this.templateCache.get(cacheKey, k -> this.getPebbleTemplate(this, templateName, templateReader));
+      try {
+        if (isNull(this.templateCache)) {
+          result = this.getPebbleTemplate(this, templateName, templateReader);
+        } else {
+          result = this.templateCache.get(cacheKey, k -> this.getPebbleTemplate(this, templateName, templateReader));
+        }
+      } finally {
+        try {
+          templateReader.close();
+        } catch (IOException e) {
+          // can't do much about it
+        }
       }
 
       return result;


### PR DESCRIPTION
Motivation:

PebbleEngine#getTemplate in branch 3 leaks file descriptor.
This issue causes test suite to often break.

Modification:

Properly close Reader.

Result:

No more fd leak and test suite runs fine.
I didn't investigate if Pebble 2 was suffereing from the same issue.