### PR TITLE
Validate leaf attribute when using maps

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/expression/GetAttributeExpression.java
@@ -106,7 +106,15 @@ public class GetAttributeExpression implements Expression<Object> {
 
                 // first we check maps
                 if (object instanceof Map) {
-                    return this.getObjectFromMap((Map<?, ?>) object, attributeNameValue);
+                    Object objectFromMap = this.getObjectFromMap((Map<?, ?>) object, attributeNameValue);
+
+                    if (context.isStrictVariables() && objectFromMap == null) {
+                        throw new AttributeNotFoundException(null, String.format(
+                                "Attribute [%s] of [%s] does not exist or can not be accessed and strict variables is set to true.",
+                                attributeName, object.getClass().getName()), attributeName, this.lineNumber, this.filename);
+                    }
+
+                    return objectFromMap;
                 }
 
                 try {

--- a/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -100,6 +100,39 @@ public class GetAttributeTest extends AbstractTest {
     }
 
     @Test
+    public void testNonExistingHashMapAttributeWithoutStrictVariables() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+
+        String source = "{{ object.nonExisting }}";
+        PebbleTemplate template = pebble.getTemplate(source);
+
+        Map<String, Object> context = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
+        map.put("name", "Steve");
+        context.put("object", map);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+        assertEquals("", writer.toString());
+    }
+
+    @Test(expected = AttributeNotFoundException.class)
+    public void testNonExistingMapAttributeWithStrictVariables() throws PebbleException, IOException {
+        PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).build();
+
+        String source = "{{ object.nonExisting }}";
+        PebbleTemplate template = pebble.getTemplate(source);
+
+        Map<String, Object> context = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
+        map.put("name", "Steve");
+        context.put("object", map);
+
+        Writer writer = new StringWriter();
+        template.evaluate(writer, context);
+    }
+
+    @Test
     public void testMethodAttribute() throws PebbleException, IOException {
         PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).build();
 


### PR DESCRIPTION
Fix bug causing leaf attribute not to be validated when using maps and strict variables set to true. Previously, for a structure like _person.name.first_ validation would have been performed for _person_ and _name_ but not for _first_.