### PR TITLE
Introduce SpecializedWriter, close #351

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/extension/writer/PooledSpecializedStringWriter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/writer/PooledSpecializedStringWriter.java
@@ -1,0 +1,86 @@
+package com.mitchellbosecke.pebble.extension.writer;
+
+import java.io.Writer;
+
+/**
+ * A ${@link SpecializedWriter} that's pooled in a ${@link ThreadLocal}.
+ * It's backed by a ${@link StringBuilder} so it's not threadsafe but doesn't involve synchronization.
+ * Beware that it has some limitations:
+ * <ul>
+ *   <li>As it's backed by a ${@link ThreadLocal}, it might leak in environments where ClassLoaders are rebooted at runtime</li>
+ *   <li>It doesn't take any security measure against very large payloads that would cause underlying buffers to eat memory</li>
+ * </ul>
+ */
+public class PooledSpecializedStringWriter extends Writer implements SpecializedWriter {
+
+  private static final ThreadLocal<PooledSpecializedStringWriter> POOL = ThreadLocal.withInitial(PooledSpecializedStringWriter::new);
+
+  private StringBuilder sb = new StringBuilder();
+
+  private PooledSpecializedStringWriter(){
+  }
+
+  @Override
+  public void writeSpecialized(int i) {
+    sb.append(i);
+  }
+
+  @Override
+  public void writeSpecialized(long l) {
+    sb.append(l);
+  }
+
+  @Override
+  public void writeSpecialized(double d) {
+    sb.append(d);
+  }
+
+  @Override
+  public void writeSpecialized(float f) {
+    sb.append(f);
+  }
+
+  @Override
+  public void writeSpecialized(short s) {
+    sb.append(s);
+  }
+
+  @Override
+  public void writeSpecialized(byte b) {
+    sb.append(b);
+  }
+
+  @Override
+  public void writeSpecialized(char c) {
+    sb.append(c);
+  }
+
+  @Override
+  public void writeSpecialized(String s) {
+    sb.append(s);
+  }
+
+  @Override
+  public void write(char[] cbuf, int off, int len) {
+    sb.append(cbuf, off, len);
+  }
+
+  @Override
+  public void flush() {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public String toString() {
+    return sb.toString();
+  }
+
+  public static PooledSpecializedStringWriter pooled() {
+    PooledSpecializedStringWriter pooled = POOL.get();
+    pooled.sb.setLength(0);
+    return pooled;
+  }
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/writer/SpecializedWriter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/writer/SpecializedWriter.java
@@ -1,0 +1,52 @@
+package com.mitchellbosecke.pebble.extension.writer;
+
+import java.math.BigDecimal;
+
+/**
+ * A special type to be implemented by ${@link java.io.Writer}s
+ * so Pebble can bypass ${@link Number}s String allocation and directly write primitives.
+ */
+public interface SpecializedWriter {
+
+  void writeSpecialized(int i);
+
+  void writeSpecialized(long l);
+
+  void writeSpecialized(double d);
+
+  void writeSpecialized(float f);
+
+  void writeSpecialized(short s);
+
+  void writeSpecialized(byte b);
+
+  void writeSpecialized(char c);
+
+  void writeSpecialized(String s);
+
+  default void write(Object o) {
+    if (o == null) {
+      throw new IllegalArgumentException("Var can not be null");
+    } else if (o instanceof String) {
+      writeSpecialized((String) o);
+    } else if (o instanceof Integer) {
+      writeSpecialized(((Integer) o).intValue());
+    } else if (o instanceof Long) {
+      writeSpecialized(((Long) o).longValue());
+    } else if (o instanceof Double) {
+      writeSpecialized(((Double) o).doubleValue());
+    } else if (o instanceof Float) {
+      writeSpecialized(((Float) o).floatValue());
+    } else if (o instanceof Short) {
+      writeSpecialized(((Short) o).shortValue());
+    } else if (o instanceof Byte) {
+      writeSpecialized(((Byte) o).byteValue());
+    } else if (o instanceof Character) {
+      writeSpecialized(((Character) o).charValue());
+    } else if (o instanceof BigDecimal) {
+      writeSpecialized(((BigDecimal) o).toPlainString());
+    } else {
+      writeSpecialized(o.toString());
+    }
+  }
+}

--- a/src/main/java/com/mitchellbosecke/pebble/extension/writer/StringWriterSpecializedAdapter.java
+++ b/src/main/java/com/mitchellbosecke/pebble/extension/writer/StringWriterSpecializedAdapter.java
@@ -1,0 +1,56 @@
+package com.mitchellbosecke.pebble.extension.writer;
+
+import java.io.StringWriter;
+
+/**
+ * A ${@link SpecializedWriter} that wraps a ${@link StringWriter}.
+ * Directly write numbers into the underlying ${@link StringBuffer} and save String allocations (compared to ${@link java.io.Writer}).
+ */
+public class StringWriterSpecializedAdapter implements SpecializedWriter {
+
+  private final StringBuffer buff;
+
+  public StringWriterSpecializedAdapter(StringWriter sw) {
+    this.buff = sw.getBuffer();
+  }
+
+  @Override
+  public void writeSpecialized(int i) {
+    buff.append(i);
+  }
+
+  @Override
+  public void writeSpecialized(long l) {
+    buff.append(l);
+  }
+
+  @Override
+  public void writeSpecialized(double d) {
+    buff.append(d);
+  }
+
+  @Override
+  public void writeSpecialized(float f) {
+    buff.append(f);
+  }
+
+  @Override
+  public void writeSpecialized(short s) {
+    buff.append(s);
+  }
+
+  @Override
+  public void writeSpecialized(byte b) {
+    buff.append(b);
+  }
+
+  @Override
+  public void writeSpecialized(char i) {
+    buff.append(i);
+  }
+
+  @Override
+  public void writeSpecialized(String s) {
+    buff.append(s);
+  }
+}

--- a/src/main/java/com/mitchellbosecke/pebble/node/PrintNode.java
+++ b/src/main/java/com/mitchellbosecke/pebble/node/PrintNode.java
@@ -10,12 +10,15 @@ package com.mitchellbosecke.pebble.node;
 
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.extension.writer.SpecializedWriter;
+import com.mitchellbosecke.pebble.extension.writer.StringWriterSpecializedAdapter;
 import com.mitchellbosecke.pebble.node.expression.Expression;
 import com.mitchellbosecke.pebble.template.EvaluationContextImpl;
 import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 import com.mitchellbosecke.pebble.utils.StringUtils;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.Writer;
 
 public class PrintNode extends AbstractRenderableNode {
@@ -32,7 +35,13 @@ public class PrintNode extends AbstractRenderableNode {
             PebbleException {
         Object var = expression.evaluate(self, context);
         if (var != null) {
-            writer.write(StringUtils.toString(var));
+            if (writer instanceof StringWriter) {
+                new StringWriterSpecializedAdapter((StringWriter) writer).write(var);
+            } else if (writer instanceof SpecializedWriter) {
+                ((SpecializedWriter) writer).write(var);
+            } else {
+                writer.write(StringUtils.toString(var));
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

* `Writer` is the central output abstraction in Pebble. Sadly, it's intended for Strings and chars so numbers have to be turned into their String representation, which cause excessive allocation for number heavy use cases.
* `StringWriter` doesn't provide any optimization for writing numbers, even though the underlying `StringBuffer` does.
* Java's standard `Writer` implementations are synchronized, which can hurt performance.

Modifications:

* Introduce `SpecializedWriter` that provides a way to optimize for writing numbers
* Provide `StringWriterSpecializedAdapter` that's used internally when user provided a `StringWriter`
* Introduce `PooledSpecializedStringWriter` for reusable in memory `StringWriter`s

Result:

Better performance