### PR TITLE
Add automatic module names

### DIFF
--- a/pebble-spring/pebble-spring-boot-2-starter/pom.xml
+++ b/pebble-spring/pebble-spring-boot-2-starter/pom.xml
@@ -38,4 +38,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.pebbletemplates.pebble.boot</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pebble-spring/pebble-spring-boot-2-starter/pom.xml
+++ b/pebble-spring/pebble-spring-boot-2-starter/pom.xml
@@ -46,7 +46,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates.pebble.boot</Automatic-Module-Name>
+              <Automatic-Module-Name>io.pebbletemplates.spring.boot</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pebble-spring/pebble-spring-boot-starter/pom.xml
+++ b/pebble-spring/pebble-spring-boot-starter/pom.xml
@@ -39,4 +39,18 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.pebbletemplates.pebble.boot</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pebble-spring/pebble-spring-boot-starter/pom.xml
+++ b/pebble-spring/pebble-spring-boot-starter/pom.xml
@@ -46,7 +46,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates.pebble.boot</Automatic-Module-Name>
+              <Automatic-Module-Name>io.pebbletemplates.spring.boot</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pebble-spring/pebble-spring3/pom.xml
+++ b/pebble-spring/pebble-spring3/pom.xml
@@ -64,4 +64,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.pebbletemplates.pebble.spring</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pebble-spring/pebble-spring3/pom.xml
+++ b/pebble-spring/pebble-spring3/pom.xml
@@ -72,7 +72,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates.pebble.spring</Automatic-Module-Name>
+              <Automatic-Module-Name>io.pebbletemplates.spring</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pebble-spring/pebble-spring4/pom.xml
+++ b/pebble-spring/pebble-spring4/pom.xml
@@ -63,4 +63,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.pebbletemplates.pebble.spring</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pebble-spring/pebble-spring4/pom.xml
+++ b/pebble-spring/pebble-spring4/pom.xml
@@ -71,7 +71,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates.pebble.spring</Automatic-Module-Name>
+              <Automatic-Module-Name>io.pebbletemplates.spring</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pebble-spring/pebble-spring5/pom.xml
+++ b/pebble-spring/pebble-spring5/pom.xml
@@ -64,4 +64,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.pebbletemplates.pebble.spring</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pebble-spring/pebble-spring5/pom.xml
+++ b/pebble-spring/pebble-spring5/pom.xml
@@ -72,7 +72,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates.pebble.spring</Automatic-Module-Name>
+              <Automatic-Module-Name>io.pebbletemplates.spring</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pebble/pom.xml
+++ b/pebble/pom.xml
@@ -71,6 +71,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.pebbletemplates.pebble</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/pebble/pom.xml
+++ b/pebble/pom.xml
@@ -75,7 +75,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates.pebble</Automatic-Module-Name>
+              <Automatic-Module-Name>io.pebbletemplates</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
         </configuration>
       </plugin>
       <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.0</version>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.21.0</version>


### PR DESCRIPTION
This is a first step towards https://github.com/PebbleTemplates/pebble/issues/391.

The primary goal for module names should be uniqueness, since they all share a namespace.
The [official naming strategy recommendation](http://mail.openjdk.java.net/pipermail/jpms-spec-experts/2017-May/000687.html) says:

> Strongly recommend that all modules be named according to the reverse
    Internet domain-name convention.  A module's name should correspond
    to the name of its principal exported API package, which should also
    follow that convention.  If a module does not have such a package, or
    if for legacy reasons it must have a name that does not correspond to
    one of its exported packages, then its name should at least start
    with the reversed form of an Internet domain with which the author is
    associated.

What makes this project special:
1. The _principal exported API package_ is  `com.mitchellbosecke.pebble` but the registered domain is `pebbletemplates.io`. Reading https://github.com/PebbleTemplates/pebble/issues/311, pebble might have such a "legacy reason" the recommendation speaks of. I therefore propose `io.pebbletemplates.pebble` as the module name. If the package name gets changed in the future it will be more intuitive, but I feel it's wrong to use @mbosecke s name without his input. I considered only `io.pebbletemplates`, but that felt too generic.
2. The spring and spring boot modules support different spring versions. Since spring doesn't change its package with new versions and it's therefore impossible to have multiple spring versions on the module path at the same time, I gave all modules the same module name `io.pebbletemplates.pebble.spring`. Also makes upgrading easier.
3. The spring boot modules have the very long package name `com.mitchellbosecke.pebble.boot.autoconfigure`. I therefore shortened the module names to `io.pebbletemplates.pebble.boot`.

Does anybody have any strong feelings about this?

Edit: If there are no objections, this is ready to merge.