### PR TITLE
Null value in a Map should not throw AttributeNotFoundException

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/attributes/MapResolver.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/attributes/MapResolver.java
@@ -26,25 +26,25 @@ class MapResolver implements AttributeResolver {
       return new ResolvedAttribute(null);
     }
 
-    ResolvedAttribute resolvedAttribute;
+    Object key;
     if (attributeNameValue != null && Number.class
         .isAssignableFrom(attributeNameValue.getClass())) {
       Number keyAsNumber = (Number) attributeNameValue;
 
       Class<?> keyClass = object.keySet().iterator().next().getClass();
-      Object key = this.cast(keyAsNumber, keyClass, filename, lineNumber);
-      resolvedAttribute = new ResolvedAttribute(object.get(key));
+      key = this.cast(keyAsNumber, keyClass, filename, lineNumber);
     } else {
-      resolvedAttribute = new ResolvedAttribute(object.get(attributeNameValue));
+      key = attributeNameValue;
     }
 
-    if (context.isStrictVariables() && resolvedAttribute.evaluatedValue == null) {
+    if(context.isStrictVariables() && !object.containsKey(key)) {
       throw new AttributeNotFoundException(null, String.format(
           "Attribute [%s] of [%s] does not exist or can not be accessed and strict variables is set to true.",
           attributeNameValue.toString(), object.getClass().getName()),
           attributeNameValue.toString(), lineNumber, filename);
     }
 
+    ResolvedAttribute resolvedAttribute = new ResolvedAttribute(object.get(key));
     return resolvedAttribute;
   }
 

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/GetAttributeTest.java
@@ -138,6 +138,43 @@ public class GetAttributeTest {
   }
 
   @Test
+  public void testNullMapValueWithoutStrictVariables() throws PebbleException, IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+        .strictVariables(false).build();
+
+    PebbleTemplate template = pebble.getTemplate("hello {{ map.name }}");
+    Map<String, Object> context = new HashMap<>();
+
+    Map<String, Object> map = new HashMap<>();
+    map.put("name", null);
+    context.put("map", map);
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer, context);
+    assertEquals("hello ", writer.toString());
+  }
+
+  /**
+   * Issue 446
+   */
+  @Test
+  public void testNullMapValueWithStrictVariables() throws PebbleException, IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
+        .strictVariables(true).build();
+
+    PebbleTemplate template = pebble.getTemplate("hello {{ map.name }}");
+    Map<String, Object> context = new HashMap<>();
+
+    Map<String, Object> map = new HashMap<>();
+    map.put("name", null);
+    context.put("map", map);
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer, context);
+    assertEquals("hello ", writer.toString());
+  }
+
+  @Test
   public void testMethodAttribute() throws PebbleException, IOException {
     PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
         .strictVariables(true).build();


### PR DESCRIPTION
Null value in a Map should not throw AttributeNotFoundException, even with StrictVariables on. (#446)