### PR TITLE
Remove unnecessary variable 'state' in LexerImpl by using Stack

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -22,7 +22,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Stack;
+import java.util.Deque;
+import java.util.ArrayDeque;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -71,7 +72,7 @@ public final class LexerImpl implements Lexer {
    * The state of the lexer is important so that we know what to expect next and to help discover
    * errors in the template (ex. unclosed comments).
    */
-  private Stack<State> states;
+  private Deque<State> states;
 
   private enum State {
     DATA, EXECUTE, PRINT, COMMENT, STRING, STRING_INTERPOLATION
@@ -154,7 +155,7 @@ public final class LexerImpl implements Lexer {
 
 
     this.tokens = new ArrayList<>();
-    this.states = new Stack<>();
+    this.states = new ArrayDeque<>();
     this.brackets = new LinkedList<>();
 
     /*


### PR DESCRIPTION
In my opinion, the 'state' variable in LexerImpl seems unnecessary. You can remove them by using Stack data structure to check the current state. (Replaced LinkedList to Stack to make it clear that the 'states' is managed by Stack)

All the test cases have passed.