### PR TITLE
Allow override core operators

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/extension/ExtensionRegistry.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/extension/ExtensionRegistry.java
@@ -59,74 +59,91 @@ public class ExtensionRegistry {
 
   private final List<AttributeResolver> attributeResolver = new ArrayList<>();
 
+  public ExtensionRegistry() {
+  }
+
   public ExtensionRegistry(Collection<? extends Extension> extensions) {
 
     for (Extension extension : extensions) {
-      // token parsers
-      List<TokenParser> tokenParsers = extension.getTokenParsers();
-      if (tokenParsers != null) {
-        for (TokenParser tokenParser : tokenParsers) {
-          this.tokenParsers.put(tokenParser.getTag(), tokenParser);
+      addExtension(extension);
+    }
+  }
+
+  public void addOperatorOverridingExtension(Extension extension) {
+    addExtension(extension, true);
+  }
+
+  public void addExtension(Extension extension) {
+    addExtension(extension, false);
+  }
+
+  private void addExtension(Extension extension, boolean operatorOverriding) {
+    // token parsers
+    List<TokenParser> tokenParsers = extension.getTokenParsers();
+    if (tokenParsers != null) {
+      for (TokenParser tokenParser : tokenParsers) {
+        this.tokenParsers.put(tokenParser.getTag(), tokenParser);
+      }
+    }
+
+    // binary operators
+    List<BinaryOperator> binaryOperators = extension.getBinaryOperators();
+    if (binaryOperators != null) {
+      for (BinaryOperator operator : binaryOperators) {
+        if (operatorOverriding) {
+          this.binaryOperators.put(operator.getSymbol(), operator);
+        } else {
+          this.binaryOperators.putIfAbsent(operator.getSymbol(), operator);
         }
       }
+    }
 
-      // binary operators
-      List<BinaryOperator> binaryOperators = extension.getBinaryOperators();
-      if (binaryOperators != null) {
-        for (BinaryOperator operator : binaryOperators) {
-          if (!this.binaryOperators
-              .containsKey(operator.getSymbol())) { // disallow overriding core operators
-            this.binaryOperators.put(operator.getSymbol(), operator);
-          }
+    // unary operators
+    List<UnaryOperator> unaryOperators = extension.getUnaryOperators();
+    if (unaryOperators != null) {
+      for (UnaryOperator operator : unaryOperators) {
+        if (operatorOverriding) {
+          this.unaryOperators.put(operator.getSymbol(), operator);
+        } else {
+          this.unaryOperators.putIfAbsent(operator.getSymbol(), operator);
         }
       }
+    }
 
-      // unary operators
-      List<UnaryOperator> unaryOperators = extension.getUnaryOperators();
-      if (unaryOperators != null) {
-        for (UnaryOperator operator : unaryOperators) {
-          if (!this.unaryOperators
-              .containsKey(operator.getSymbol())) { // disallow override core operators
-            this.unaryOperators.put(operator.getSymbol(), operator);
-          }
-        }
-      }
+    // filters
+    Map<String, Filter> filters = extension.getFilters();
+    if (filters != null) {
+      this.filters.putAll(filters);
+    }
 
-      // filters
-      Map<String, Filter> filters = extension.getFilters();
-      if (filters != null) {
-        this.filters.putAll(filters);
-      }
+    // tests
+    Map<String, Test> tests = extension.getTests();
+    if (tests != null) {
+      this.tests.putAll(tests);
+    }
 
-      // tests
-      Map<String, Test> tests = extension.getTests();
-      if (tests != null) {
-        this.tests.putAll(tests);
-      }
+    // functions
+    Map<String, Function> functions = extension.getFunctions();
+    if (functions != null) {
+      this.functions.putAll(functions);
+    }
 
-      // tests
-      Map<String, Function> functions = extension.getFunctions();
-      if (functions != null) {
-        this.functions.putAll(functions);
-      }
+    // global variables
+    Map<String, Object> globalVariables = extension.getGlobalVariables();
+    if (globalVariables != null) {
+      this.globalVariables.putAll(globalVariables);
+    }
 
-      // global variables
-      Map<String, Object> globalVariables = extension.getGlobalVariables();
-      if (globalVariables != null) {
-        this.globalVariables.putAll(globalVariables);
-      }
+    // node visitors
+    List<NodeVisitorFactory> nodeVisitors = extension.getNodeVisitors();
+    if (nodeVisitors != null) {
+      this.nodeVisitors.addAll(nodeVisitors);
+    }
 
-      // node visitors
-      List<NodeVisitorFactory> nodeVisitors = extension.getNodeVisitors();
-      if (nodeVisitors != null) {
-        this.nodeVisitors.addAll(nodeVisitors);
-      }
-
-      // attribute resolver
-      List<AttributeResolver> attributeResolvers = extension.getAttributeResolver();
-      if (attributeResolvers != null) {
-        this.attributeResolver.addAll(attributeResolvers);
-      }
+    // attribute resolver
+    List<AttributeResolver> attributeResolvers = extension.getAttributeResolver();
+    if (attributeResolvers != null) {
+      this.attributeResolver.addAll(attributeResolvers);
     }
   }
 

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/OverrideCoreExtensionTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/OverrideCoreExtensionTest.java
@@ -1,32 +1,40 @@
 package com.mitchellbosecke.pebble;
 
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
 import com.mitchellbosecke.pebble.extension.Filter;
 import com.mitchellbosecke.pebble.extension.Function;
 import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.node.expression.BinaryExpression;
+import com.mitchellbosecke.pebble.node.expression.UnaryExpression;
+import com.mitchellbosecke.pebble.operator.Associativity;
+import com.mitchellbosecke.pebble.operator.BinaryOperator;
+import com.mitchellbosecke.pebble.operator.BinaryOperatorImpl;
+import com.mitchellbosecke.pebble.operator.UnaryOperator;
+import com.mitchellbosecke.pebble.operator.UnaryOperatorImpl;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.EvaluationContextImpl;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
-
-import org.junit.Test;
-
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class OverrideCoreExtensionTest {
+
   @Test
   public void testOverrideCodeExtensionFunction() throws IOException {
     PebbleEngine pebble = new PebbleEngine.Builder()
-            .loader(new StringLoader())
-            .extension(new TestExtension())
-            .strictVariables(false)
-            .build();
+        .loader(new StringLoader())
+        .extension(new TestExtension())
+        .build();
 
     PebbleTemplate template = pebble.getTemplate("{{i18n()}}");
 
@@ -38,16 +46,73 @@ public class OverrideCoreExtensionTest {
   @Test
   public void testOverrideCodeExtensionFilter() throws IOException {
     PebbleEngine pebble = new PebbleEngine.Builder()
-            .loader(new StringLoader())
-            .extension(new TestExtension())
-            .strictVariables(false)
-            .build();
+        .loader(new StringLoader())
+        .extension(new TestExtension())
+        .build();
 
     PebbleTemplate template = pebble.getTemplate("{{ null | date }}");
 
     Writer writer = new StringWriter();
     template.evaluate(writer);
     assertEquals("custom date filter", writer.toString());
+  }
+
+  @Test
+  public void testOverrideCoreExtensionUnaryOperator() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder()
+        .loader(new StringLoader())
+        .extension(new TestExtension())
+        .allowOverrideCoreOperators(true)
+        .build();
+
+    PebbleTemplate template = pebble.getTemplate("{{ not true }}");
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer);
+    assertEquals("custom unary operator", writer.toString());
+  }
+
+  @Test
+  public void testByDefaultPreventsOverrideCoreExtensionUnaryOperator() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder()
+        .loader(new StringLoader())
+        .extension(new TestExtension())
+        .build();
+
+    PebbleTemplate template = pebble.getTemplate("{{ not true }}");
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer);
+    assertEquals("false", writer.toString());
+  }
+
+  @Test
+  public void testOverrideCoreExtensionBinaryOperator() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder()
+        .loader(new StringLoader())
+        .extension(new TestExtension())
+        .allowOverrideCoreOperators(true)
+        .build();
+
+    PebbleTemplate template = pebble.getTemplate("{{ 2 == 2 }}");
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer);
+    assertEquals("custom binary operator", writer.toString());
+  }
+
+  @Test
+  public void testByDefaultPreventsOverrideCoreExtensionBinaryOperator() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder()
+        .loader(new StringLoader())
+        .extension(new TestExtension())
+        .build();
+
+    PebbleTemplate template = pebble.getTemplate("{{ 2 == 2 }}");
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer);
+    assertEquals("true", writer.toString());
   }
 
   private static class TestExtension extends AbstractExtension {
@@ -65,11 +130,29 @@ public class OverrideCoreExtensionTest {
       filters.put("date", new CustomDateFilter());
       return filters;
     }
+
+    @Override
+    public List<BinaryOperator> getBinaryOperators() {
+      BinaryOperatorImpl equalsOperator = new BinaryOperatorImpl(
+          "==", 30, FakeEqualsExpression.class, Associativity.LEFT);
+
+      return singletonList(equalsOperator);
+    }
+
+    @Override
+    public List<UnaryOperator> getUnaryOperators() {
+      UnaryOperatorImpl equalsOperator = new UnaryOperatorImpl(
+          "not", 500, FakeUnaryNotExpression.class);
+
+      return singletonList(equalsOperator);
+    }
   }
 
   private static class CustomI18nFunction implements Function {
+
     @Override
-    public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+    public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context,
+        int lineNumber) {
       return "custom i18n function";
     }
 
@@ -79,9 +162,27 @@ public class OverrideCoreExtensionTest {
     }
   }
 
-  private static class CustomDateFilter implements Filter {
+  public static class FakeEqualsExpression extends BinaryExpression<String> {
+
     @Override
-    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) throws PebbleException {
+    public String evaluate(PebbleTemplateImpl self, EvaluationContextImpl context) {
+      return "custom binary operator";
+    }
+  }
+
+  public static class FakeUnaryNotExpression extends UnaryExpression {
+
+    @Override
+    public String evaluate(PebbleTemplateImpl self, EvaluationContextImpl context) {
+      return "custom unary operator";
+    }
+  }
+
+  private static class CustomDateFilter implements Filter {
+
+    @Override
+    public Object apply(Object input, Map<String, Object> args, PebbleTemplate self,
+        EvaluationContext context, int lineNumber) throws PebbleException {
       return "custom date filter";
     }
 


### PR DESCRIPTION
Resolves #455.

Added `allowOverrideCoreOperators` flag to `PebbleEngine.Builder`. It defaults to `false` to preserve backwards compatibility.

Example usage:

```java
    PebbleEngine pebble = new PebbleEngine.Builder()
        .loader(new StringLoader())
        .extension(new TestExtension())
        .allowOverrideCoreOperators(true)
        .build();
```

If enabled, it will apply **all** operators defined in provided extension class.
Otherwise it will only apply those operators that are **not already defined** in `CoreExtension.class` operators.

