### PR TITLE
Fix issue deploying Orchid docs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -16,7 +16,7 @@
   <url>http://pebbletemplates.io</url>
 
   <properties>
-    <orchid.version>0.17.1</orchid.version>
+    <orchid.version>0.17.4</orchid.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
The issue deploying to GithubPages is fixed in the latest version of Orchid. 
I reproduced the authentication error on 0.17.1, and after updating to 0.17.4 I was able to successfully deploy to my fork. I tested it with the Github token set as both an environment variable and as a Maven CLI property, both successful.