### PR TITLE
Whitespace Control Template Tests with New Line Trimming Disabled

### DIFF
--- a/docs/src/orchid/resources/wiki/tag/verbatim.md
+++ b/docs/src/orchid/resources/wiki/tag/verbatim.md
@@ -1,9 +1,25 @@
 # `verbatim`
-The `verbatim` tag allows you to write Pebble syntax that won't be parsed.
+The `verbatim` tag allows you to write a block of Pebble syntax that won't be parsed.
 ```twig
 {% verbatim %}
 	{% for user in users %}
 		{{ user.name }}
-	{% endfor %}}
+	{% endfor %}
 {% endverbatim %}
+```
+<br/>
+## Inline Verbatim Text
+
+For inline verbatim text, a string literal can be used. For example, if you need to include **{{** in the output of a template, you can use `{{ "{{" }}` in string literal in the Pebble template 
+
+This would be useful if you are using Pebble to generate Angular HTML component template files:
+
+```javascript
+<td>{{ "{{" }}school.name{{ "}}" }}</td>
+```
+
+would produce the following template output:
+
+```javascript
+<td>{{school.name}}</td>
 ```

--- a/pebble/pom.xml
+++ b/pebble/pom.xml
@@ -66,6 +66,20 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+	<dependency>
+	    <groupId>org.assertj</groupId>
+	    <artifactId>assertj-core</artifactId>
+	    <version>3.13.2</version>
+	    <scope>test</scope>
+	</dependency>
+    <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+	<dependency>
+	    <groupId>commons-io</groupId>
+	    <artifactId>commons-io</artifactId>
+	    <version>2.6</version>
+	    <scope>test</scope>
+	</dependency>
   </dependencies>
 
   <build>

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/NewlineTrimmingTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/NewlineTrimmingTest.java
@@ -61,8 +61,13 @@ public class NewlineTrimmingTest {
     assertEquals("val1val2", writer.toString());
   }
 
+  /**
+   * Given that Newline Trimming is disabled, 
+   * a template that contains one newline character with text on each line
+   * should output one newline character.
+   */
   @Test
-  public void testPrintSetToFalse() throws PebbleException, IOException {
+  public void testNewLineIncludedWhen_NewLineTrimmingIsFalse() throws PebbleException, IOException {
 
     PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
         .newLineTrimming(false)
@@ -100,8 +105,13 @@ public class NewlineTrimmingTest {
     assertEquals("val1\nval2", writer.toString());
   }
 
+  /**
+   * Given that Newline Trimming is disabled, 
+   * a template that contains one or more consecutive newline characters
+   * should output one newline character.
+   */
   @Test
-  public void testPrintSetToFalseTwoNewlines() throws PebbleException, IOException {
+  public void testOneNewLineWhen_NewLineTrimmingFalseAndConsecutiveNewLinesInTemplate() throws PebbleException, IOException {
 
     PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader())
         .newLineTrimming(false)

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/PebbleTestContext.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/PebbleTestContext.java
@@ -1,0 +1,154 @@
+package com.mitchellbosecke.pebble.template.tests;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mitchellbosecke.pebble.PebbleEngine;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+/**
+ * Used by Pebble Template Tests to simply the test code and therefore 
+ * make it easier to understand what is tested by each test.
+ * 
+ *  A separate instance of this class should be instantiated for each
+ *  template test, i.e. for each instance of a template. 
+ * 
+ * @author nathanward
+ */
+public class PebbleTestContext {
+
+	private final Logger logger = LoggerFactory.getLogger(PebbleTestContext.class);
+	
+	/**
+	 * The path relative to the project root directory where template files and 
+	 * expected output files are stored for test purposes.
+	 */
+	private String testFileBasePath = "src/test/resources/template-tests";
+	
+	/**
+	 * The Pebble template context to be used as input for a Pebble Template. 
+	 */
+	private Map<String, Object> templateContext = null;
+
+	/**
+	 * Whether or not the Pebble Engine instantiated will 
+	 * enable New Line Trimming on the Builder when this class instantiates
+	 * a Pebble Engine instance. Defaults to <code>true</code>.
+	 */
+	private boolean newLineTrimming = true;
+	
+	/**
+	 * Initialize the Pebble Template Context.
+	 */ 
+	public PebbleTestContext() {
+		this.templateContext = new HashMap<String, Object>();
+	}
+	
+	public void setNewLineTrimming(boolean b) {
+		this.newLineTrimming  = b;
+	}
+	
+	/**
+	 * Put an object into the Pebble template context to be used as input for
+	 * when the template is executed. One or more items can be put into the template
+	 * context.
+	 * 
+	 * @param name Template input/parameter name (i.e. key) for use within the template
+	 * @param value The object that will be referred to by the given name in the template
+	 */
+	public void setTemplateInput(String name, Object value) {
+		this.templateContext.put(name, value);
+	}
+
+	/**
+	 * Load the specified template file and execute the template using a 
+	 * Pebble Engine using the default Builder (classpath and file builder). 
+	 * 
+	 * @param templateFilename The template filename relative to the Test File Base Path
+	 * 
+	 * @return The output of the template as a string.
+	 * 
+	 * @throws IOException Thrown if the template file is not found. 
+	 */
+	public String executeTemplateFromFile(String templateFilename) throws IOException {
+		PebbleEngine pebbleEngine = new PebbleEngine.Builder()
+				.newLineTrimming(this.newLineTrimming).strictVariables(true).build();
+		return this.executeTemplateFromFile(templateFilename, pebbleEngine);
+	}
+	
+	/**
+	 * Execute a template given a template file and a Pebble Engine instance. 
+	 * 
+	 * @param templateFilename The template filename relative to the Test File Base Path
+	 * @param pebbleEngine
+	 * @return
+	 * @throws IOException
+	 */
+	public String executeTemplateFromFile(String templateFilename, PebbleEngine pebbleEngine) throws IOException {
+		Path path = Paths.get(this.testFileBasePath, templateFilename);
+		logger.debug("Executing template file: {}", path.toString());
+		return this.executeTemplate(path.toAbsolutePath().toString(), pebbleEngine);
+	}
+		
+	/**
+	 * Load the specified template file and execute the template using a 
+	 * Pebble Engine using the default Builder (classpath and file builder). 
+	 * 
+	 * @param templateString The template content as a string
+	 * 
+	 * @return The output of the template as a string.
+	 * 
+	 * @throws IOException Thrown if the template file is not found. 
+	 */
+	public String executeTemplateFromString(String templateString) throws IOException {
+		PebbleEngine pebbleEngine = new PebbleEngine.Builder().loader(new StringLoader())
+				.newLineTrimming(this.newLineTrimming).build();
+		return this.executeTemplate(templateString, pebbleEngine);
+	}
+	
+	/**
+	 * Load the specified template file and execute the template using the template input
+	 * that has previously been specified using the setTemplateInput() method. 
+	 * 
+	 * @param templateFilename The template filename relative to the Test File Base Path
+	 * @param pebbleEngine The Pebble Engine to be used to execute the template
+	 * @return The output of the template as a string.
+	 * 
+	 * @throws IOException Thrown if the template file is not found. 
+	 */
+	public String executeTemplate(String templateName, PebbleEngine pebbleEngine) throws IOException {
+		PebbleTemplate template = pebbleEngine.getTemplate(templateName);		
+		Writer writer = new StringWriter();
+		template.evaluate(writer, this.templateContext);
+		String templateOutput = writer.toString();
+		logger.debug("Template Output: {}", templateOutput);
+		return templateOutput;
+	}
+	
+	/**
+	 * Get the Expected Output content for the given filename so that the 
+	 * base path to the expected template output file does not have to be
+	 * specified in the actual test code. 
+	 * 
+	 * @param filename The name of the file that contains the expected template output. 
+	 * @return The content of the expected template output file as a string.
+	 * @throws IOException Thrown if the file by the given name is not found.
+	 */
+	public String getExpectedOutput(String filename) throws IOException {
+		Path path = Paths.get(this.testFileBasePath, filename);
+	    logger.debug("Expected template output file: {}", path.toAbsolutePath());
+	    String expectedOutput = FileUtils.readFileToString(path.toFile(), "UTF-8");
+	    return expectedOutput;
+	}
+	
+}

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/WhiteSpaceControlWithNewLineTrimmingTests.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/WhiteSpaceControlWithNewLineTrimmingTests.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.mitchellbosecke.pebble.template.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.tests.input.PebbleTestItem;
+import com.mitchellbosecke.pebble.template.tests.input.PebbleTestItemType;
+
+/**
+ * Tests of whitespace control when New Line Trimming is enabled. 
+ * This mainly affects vertical spacing, i.e. the control of blank lines. 
+ * With New Line Trimming enabled, Pebble control statements on a line
+ * by themselves products a blank line in the output unless 
+ * the Whitespace Control Modifier is used before and/or after the 
+ * control statement, i.e. the dash character, e.g.  `{% if item.itemType equals "ITEM_TYPE1" -%}`.
+ * 
+ * However, it can be difficult to get the blank lines to come out as expected
+ * in the case that nested control structures are used.
+ * 
+ * @author nathanward
+ */
+public class WhiteSpaceControlWithNewLineTrimmingTests {
+
+	/**
+	 * All tests in this class use this list of objects as the input to the template.
+	 */
+	private List<PebbleTestItem> listOfObjects = new ArrayList<PebbleTestItem>();
+	
+	/**
+	 * Used by each test and initialized before each test to simplify the 
+	 * test execution, which helps make the purpose of each test clear.
+	 */
+	private PebbleTestContext pebbleTestContext = null;
+	
+	@Before
+	public void setup() {
+		listOfObjects.add(new PebbleTestItem("Item 1", PebbleTestItemType.ITEM_TYPE1));
+		listOfObjects.add(new PebbleTestItem("Item 2", PebbleTestItemType.ITEM_TYPE2));
+		listOfObjects.add(new PebbleTestItem("Item 3", PebbleTestItemType.ITEM_TYPE3, true));
+		listOfObjects.add(new PebbleTestItem("Item 4", PebbleTestItemType.ITEM_TYPE4));
+		
+		pebbleTestContext = new PebbleTestContext();
+		pebbleTestContext.setNewLineTrimming(false);
+		pebbleTestContext.setTemplateInput("items", listOfObjects);
+	}
+
+	/**
+	 * Test the whitespace control for a template that has a <code>for</code> loop with a nested
+	 * <code>if</code> statement where some text is output for each item in the list.
+	 * 
+	 * @throws PebbleException
+	 * @throws IOException
+	 */
+	@Test
+	public void testForLoopWithNestedIfStatement() throws PebbleException, IOException {
+		String templateOutput = pebbleTestContext.executeTemplateFromFile("ForLoopWithNestedIfStatement.peb");
+		assertThat(templateOutput).contains(pebbleTestContext.getExpectedOutput("ForLoopWithNestedIfStatement.txt"));
+	}
+
+	/**
+	 * Test the whitespace control for a template that has a <code>for</code> loop with a nested
+	 * <code>if</code> statement that uses a macro and the macro also has an if statement. 
+	 * 
+	 * @throws PebbleException
+	 * @throws IOException
+	 */
+	@Test
+	public void testForLoopWithNestedIfStatementAndMacro() throws PebbleException, IOException {;		
+		String templateOutput = pebbleTestContext.executeTemplateFromFile("ForLoopWithNestedIfStatementAndMacro.peb");
+		assertThat(templateOutput).contains(pebbleTestContext.getExpectedOutput("ForLoopWithNestedIfStatementAndMacro.txt"));
+	}
+	
+	/**
+	 * Test the whitespace control for a template that has a <code>for</code> loop with a nested
+	 * <code>if</code> statement that skips some of the items in the for loop.
+	 * 
+	 * @throws PebbleException
+	 * @throws IOException
+	 */
+	@Ignore("Fails due to extra blank line in the case that the if condition in the template is is not met")
+	@Test
+	public void testForLoopWithNestedIfStatementThatIsSkipped() throws IOException {
+		String templateOutput = pebbleTestContext.executeTemplateFromFile("ForLoopWithNestedIfStatementThatIsSkipped.peb");
+		assertThat(templateOutput).contains(pebbleTestContext.getExpectedOutput("ForLoopWithNestedIfStatementThatIsSkipped.txt"));
+	}
+}

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/input/PebbleTestItem.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/input/PebbleTestItem.java
@@ -1,0 +1,46 @@
+package com.mitchellbosecke.pebble.template.tests.input;
+
+public class PebbleTestItem {
+
+	private String name;
+	
+	private PebbleTestItemType itemType;
+	
+	private boolean hasPrefix;
+
+	public PebbleTestItem(String name, PebbleTestItemType itemType1) {
+		this.name = name;
+		this.itemType = itemType1;
+	}
+
+	public PebbleTestItem(String name, PebbleTestItemType itemType1, boolean hasPrefix) {
+		this.name = name;
+		this.itemType = itemType1;
+		this.hasPrefix = hasPrefix;
+	}
+	
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public PebbleTestItemType getItemType() {
+		return itemType;
+	}
+
+	public void setItemType(PebbleTestItemType pebbleTestItemType) {
+		this.itemType = pebbleTestItemType;
+	}
+
+	public boolean isHasPrefix() {
+		return hasPrefix;
+	}
+
+	public void setHasPrefix(boolean hasPrefix) {
+		this.hasPrefix = hasPrefix;
+	}
+	
+}

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/input/PebbleTestItemType.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/template/tests/input/PebbleTestItemType.java
@@ -1,0 +1,5 @@
+package com.mitchellbosecke.pebble.template.tests.input;
+
+public enum PebbleTestItemType {
+	ITEM_TYPE1, ITEM_TYPE2, ITEM_TYPE3, ITEM_TYPE4
+}

--- a/pebble/src/test/resources/logback-test.xml
+++ b/pebble/src/test/resources/logback-test.xml
@@ -9,4 +9,7 @@
   <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
+  
+  <logger name="com.mitchellbosecke.pebble.template.tests" level="DEBUG"/>
+  
 </configuration>

--- a/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatement.peb
+++ b/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatement.peb
@@ -1,0 +1,13 @@
+text before for loop followed by blank line
+{% for item in items %}
+{% if item.itemType equals "ITEM_TYPE1" -%}
+Item 1
+{% elseif item.itemType equals "ITEM_TYPE2" -%}
+Item 2
+{% elseif item.itemType equals "ITEM_TYPE3" -%}
+Item 3
+{% elseif item.itemType equals "ITEM_TYPE4" -%}
+Item 4
+{% endif -%}
+{% endfor %}
+text after for loop preceded by blank line

--- a/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatement.txt
+++ b/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatement.txt
@@ -1,0 +1,11 @@
+text before for loop followed by blank line
+
+Item 1
+
+Item 2
+
+Item 3
+
+Item 4
+
+text after for loop preceded by blank line

--- a/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementAndMacro.peb
+++ b/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementAndMacro.peb
@@ -1,0 +1,17 @@
+text before for loop followed by blank line
+{% for item in items %}
+{% if item.itemType equals "ITEM_TYPE1" -%}
+{{ item.name }}
+{% else -%}
+{{ itemStatement(item) }}
+{% endif -%}
+{% endfor %}
+text after for loop preceded by blank line
+
+
+{%- macro itemStatement(item) -%}
+{%- if item.hasPrefix == true -%}
+Prefix Text
+{% endif -%}
+{{ item.name }}
+{%- endmacro -%}

--- a/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementAndMacro.txt
+++ b/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementAndMacro.txt
@@ -1,0 +1,12 @@
+text before for loop followed by blank line
+
+Item 1
+
+Item 2
+
+Prefix Text
+Item 3
+
+Item 4
+
+text after for loop preceded by blank line

--- a/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementThatIsSkipped.peb
+++ b/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementThatIsSkipped.peb
@@ -1,0 +1,9 @@
+text before for loop followed by blank line
+{% for item in items %}
+{% if item.itemType equals "ITEM_TYPE1" -%}
+Item 1
+{% elseif item.itemType equals "ITEM_TYPE2" -%}
+Item 2
+{% endif -%}
+{% endfor %}
+text after for loop preceded by blank line

--- a/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementThatIsSkipped.txt
+++ b/pebble/src/test/resources/template-tests/ForLoopWithNestedIfStatementThatIsSkipped.txt
@@ -1,0 +1,7 @@
+text before for loop followed by blank line
+
+Item 1
+
+Item 2
+
+text after for loop preceded by blank line


### PR DESCRIPTION
I added tests for whitespace control for templates when **New Line Trimming is disabled**. Also added **assertj** and **commons-io** Maven dependencies for use in the tests. Commons IO is used to compare template output to expected output that is loaded from a file. Loading the expected template output from a file is useful for testing multiline template output, which is necessary to test various scenarios. These are a form of Integration Test rather than Unit Tests and so it is practical and reasonable to verify the template output in this way.

Related issue: https://github.com/PebbleTemplates/pebble/issues/470#issue-488221680