### PR TITLE
Added StringResolver

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/extension/escaper/EscapeFilter.java
@@ -61,7 +61,12 @@ public class EscapeFilter implements Filter {
     if (inputObject == null || inputObject instanceof SafeString) {
       return inputObject;
     }
-    String input = StringUtils.toString(inputObject);
+    String input;
+    if (inputObject instanceof StringResolver) {
+      input = ((StringResolver)inputObject).resolve(inputObject, self, context, lineNumber);
+    } else {
+      input = StringUtils.toString(inputObject);
+    }
 
     String strategy = this.defaultStrategy;
 

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/extension/escaper/RawFilter.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/extension/escaper/RawFilter.java
@@ -23,6 +23,9 @@ public class RawFilter implements Filter {
   @Override
   public Object apply(Object inputObject, Map<String, Object> args, PebbleTemplate self,
       EvaluationContext context, int lineNumber) {
+    if (inputObject instanceof StringResolver) {
+      return new SafeString(((StringResolver)inputObject).resolve(inputObject, self, context, lineNumber));
+    }
     return inputObject == null ? null : new SafeString(inputObject.toString());
   }
 

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/extension/escaper/StringResolver.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/extension/escaper/StringResolver.java
@@ -1,0 +1,20 @@
+/*
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2019 by Axel Dörfler
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.mitchellbosecke.pebble.extension.escaper;
+
+import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+public interface StringResolver
+{
+  String resolve(Object instance,
+      PebbleTemplate self,
+      EvaluationContext context,
+      int lineNumber);
+}

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/EscaperExtensionTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/EscaperExtensionTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotEquals;
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.extension.AbstractExtension;
 import com.mitchellbosecke.pebble.extension.Function;
+import com.mitchellbosecke.pebble.extension.escaper.StringResolver;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
@@ -291,6 +292,31 @@ public class EscaperExtensionTest {
     template.evaluate(writer, context);
 
     assertEquals("{\\\"a\\\": \\\"a/b/c\\\"}", writer.toString());
+  }
+
+  @Test
+  public void testStringResolver() throws PebbleException, IOException {
+      PebbleEngine pebble = new PebbleEngine.Builder()
+          .loader(new StringLoader())
+          .strictVariables(false)
+          .build();
+
+      PebbleTemplate template = pebble.getTemplate("{{ object }} - {{ object | raw }}");
+
+      Map<String, Object> context = new HashMap<>();
+      context.put("object", new StringResolver() {
+        @Override
+        public String resolve(Object instance, PebbleTemplate self, EvaluationContext context,
+            int lineNumber)
+        {
+            return "yes<br/>";
+        }
+      });
+
+      Writer writer = new StringWriter();
+      template.evaluate(writer, context);
+
+      assertEquals("yes&lt;br/&gt; - yes<br/>", writer.toString());
   }
 
   public static class TestExtension extends AbstractExtension {


### PR DESCRIPTION
This allows to replace the toString() method that is used in RawFilter
and EscapeFilter with one that has access to the context, ie. to access
the current locale and other things.