### PR TITLE
Extract Scope interface

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplateImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/template/PebbleTemplateImpl.java
@@ -104,6 +104,21 @@ public class PebbleTemplateImpl implements PebbleTemplate {
     this.evaluate(writer, context);
   }
 
+  public void evaluate(Writer writer, Scope scope, Locale locale) throws IOException {
+    EvaluationContextImpl context = this.initContext(locale);
+    context.getScopeChain().pushScope(scope);
+
+    if (!scope.isWritable()) {
+      context.getScopeChain().pushScope(new HashMap<>());
+    }
+
+    this.evaluate(writer, context);
+  }
+
+  public void evaluate(Writer writer, Scope scope) throws IOException {
+    evaluate(writer, scope, null);
+  }
+
   public void evaluateBlock(String blockName, Writer writer) throws IOException {
     EvaluationContextImpl context = this.initContext(null);
     this.evaluate(new NoopWriter(), context);

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/template/Scope.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/template/Scope.java
@@ -1,15 +1,4 @@
-/*
- * This file is part of Pebble.
- * <p>
- * Copyright (c) 2014 by Mitchell Bösecke
- * <p>
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 package com.mitchellbosecke.pebble.template;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A scope is a map of variables. A "local" scope ensures that the search for a particular variable
@@ -17,83 +6,55 @@ import java.util.Map;
  *
  * @author Mitchell
  */
-public class Scope {
+public interface Scope {
+    /**
+     * Creates a shallow copy of the Scope.
+     * <p>
+     * This is used for the parallel tag  because every new thread should have a "snapshot" of the
+     * scopes, i.e. one thread should not affect rendering output of another.
+     * <p>
+     * It will construct a new collection but it will contain references to all of the original
+     * variables therefore it is not a deep copy. This is why it is import for the user to use
+     * thread-safe variables when using the parallel tag.
+     *
+     * @return A copy of the scope
+     */
+    Scope shallowCopy();
 
-  /**
-   * A "local" scope ensures that the search for a particular variable will end at this scope
-   * whether or not it was found.
-   */
-  private final boolean local;
+    /**
+     * Adds a variable to this scope
+     *
+     * @param key The name of the variable
+     * @param value The value of the variable
+     */
+    void put(String key, Object value);
 
-  /**
-   * The map of variables known at this scope
-   */
-  private final Map<String, Object> backingMap;
+    /**
+     * Retrieves the variable at this scope
+     *
+     * @param key The name of the variable
+     * @return The value of the variable
+     */
+    Object get(String key);
 
-  /**
-   * Constructor
-   *
-   * @param backingMap The backing map of variables
-   * @param local Whether this scope is local or not
-   */
-  public Scope(Map<String, Object> backingMap, boolean local) {
-    this.backingMap = backingMap == null ? new HashMap<>() : backingMap;
-    this.local = local;
-  }
+    /**
+     * Checks if this scope contains a variable of a certain name.
+     *
+     * @param key The name of the variable
+     * @return boolean stating whether or not the backing map of this scope contains that variable
+     */
+    boolean containsKey(String key);
 
-  /**
-   * Creates a shallow copy of the Scope.
-   * <p>
-   * This is used for the parallel tag  because every new thread should have a "snapshot" of the
-   * scopes, i.e. one thread should not affect rendering output of another.
-   * <p>
-   * It will construct a new collection but it will contain references to all of the original
-   * variables therefore it is not a deep copy. This is why it is import for the user to use
-   * thread-safe variables when using the parallel tag.
-   *
-   * @return A copy of the scope
-   */
-  public Scope shallowCopy() {
-    Map<String, Object> backingMapCopy = new HashMap<>(this.backingMap);
-    return new Scope(backingMapCopy, this.local);
-  }
+    /**
+     * Returns whether or not this scope is "local".
+     *
+     * @return boolean stating whether this scope is local or not.
+     */
+    boolean isLocal();
 
-  /**
-   * Adds a variable to this scope
-   *
-   * @param key The name of the variable
-   * @param value The value of the variable
-   */
-  public void put(String key, Object value) {
-    this.backingMap.put(key, value);
-  }
-
-  /**
-   * Retrieves the variable at this scope
-   *
-   * @param key The name of the variable
-   * @return The value of the variable
-   */
-  public Object get(String key) {
-    return this.backingMap.get(key);
-  }
-
-  /**
-   * Checks if this scope contains a variable of a certain name.
-   *
-   * @param key The name of the variable
-   * @return boolean stating whether or not the backing map of this scope contains that variable
-   */
-  public boolean containsKey(String key) {
-    return this.backingMap.containsKey(key);
-  }
-
-  /**
-   * Returns whether or not this scope is "local".
-   *
-   * @return boolean stating whether this scope is local or not.
-   */
-  public boolean isLocal() {
-    return this.local;
-  }
+    /**
+     * Indicate that this scope supports put operation
+     * @return true if modifications are supported
+     */
+    boolean isWritable();
 }

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/template/ScopeChain.java
@@ -67,7 +67,16 @@ public class ScopeChain {
    * @param map The known variables of this scope.
    */
   public void pushScope(Map<String, Object> map) {
-    Scope scope = new Scope(map, false);
+    Scope scope = new ScopeImpl(map, false);
+    this.stack.push(scope);
+  }
+
+  /**
+   * Push new scope to the chain
+   *
+   * @param scope Scope instance
+   */
+  public void pushScope(Scope scope) {
     this.stack.push(scope);
   }
 
@@ -75,7 +84,7 @@ public class ScopeChain {
    * Adds a new local scope to the scope chain
    */
   public void pushLocalScope() {
-    Scope scope = new Scope(new HashMap<>(), true);
+    Scope scope = new ScopeImpl(new HashMap<>(), true);
     this.stack.push(scope);
   }
 

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/template/ScopeImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/template/ScopeImpl.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Pebble.
+ * <p>
+ * Copyright (c) 2014 by Mitchell Bösecke
+ * <p>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.mitchellbosecke.pebble.template;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A scope is a map of variables. A "local" scope ensures that the search for a particular variable
+ * will end at this scope whether or not it was found.
+ *
+ * @author Mitchell
+ */
+public class ScopeImpl implements Scope {
+
+  /**
+   * A "local" scope ensures that the search for a particular variable will end at this scope
+   * whether or not it was found.
+   */
+  private final boolean local;
+
+  /**
+   * The map of variables known at this scope
+   */
+  private final Map<String, Object> backingMap;
+
+  /**
+   * Constructor
+   *
+   * @param backingMap The backing map of variables
+   * @param local Whether this scope is local or not
+   */
+  public ScopeImpl(Map<String, Object> backingMap, boolean local) {
+    this.backingMap = backingMap == null ? new HashMap<>() : backingMap;
+    this.local = local;
+  }
+
+  @Override
+  public Scope shallowCopy() {
+    Map<String, Object> backingMapCopy = new HashMap<>(this.backingMap);
+    return new ScopeImpl(backingMapCopy, this.local);
+  }
+
+  @Override
+  public void put(String key, Object value) {
+    this.backingMap.put(key, value);
+  }
+
+  @Override
+  public Object get(String key) {
+    return this.backingMap.get(key);
+  }
+
+  @Override
+  public boolean containsKey(String key) {
+    return this.backingMap.containsKey(key);
+  }
+
+  @Override
+  public boolean isLocal() {
+    return this.local;
+  }
+
+  @Override
+  public boolean isWritable() {
+    return false;
+  }
+}


### PR DESCRIPTION
Changes: 
* Extract interface Scope and move implementation to ScopeImpl. Use interface where possible.
* Add isWritable() method to the Scope
* Add evaluate(Writer writer, Scope scope) method to PebbleTemplateImpl 

After change in https://github.com/PebbleTemplates/pebble/issues/449 i no long can save context between evaluate calls so if template set/update some variable it will not be visible in subsequent execution of evaluate with same map instance. 
In my case it is necessary feature so i proposing this abstraction which also should target cases where context map is not a map itself but some proxy/dynamic content and creating java.util.Map proxy implementation might be dirty solution. 

Important is a way to share same context between evaluate calls somehow. If there is another better  solution im glad to implement it instead.
