### PR TITLE
Fix variable name starting with operator

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -662,7 +662,7 @@ public final class LexerImpl implements Lexer {
        */
       char nextChar = operator.charAt(operator.length() - 1);
       if (Character.isLetter(nextChar) || Character.getType(nextChar) == Character.LETTER_NUMBER) {
-        regex.append("(?![a-zA-Z])");
+        regex.append("(?![a-zA-Z0-9_])");
       }
     }
 

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/lexer/LexerImplTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/lexer/LexerImplTest.java
@@ -83,6 +83,36 @@ class LexerImplTest {
   }
 
   /**
+   * Test tokenizing an expression, e.g. {{ expression }}
+   */
+  @Test
+  void testVariableNameStartingWithOperator() {
+    Loader<String> loader = new StringLoader();
+    Reader templateReader = loader.getReader("{{ is_active + contains0 }}");
+
+    TokenStream tokenStream = this.lexer.tokenize(templateReader, this.TEMPLATE_NAME);
+
+    int i = 0;
+    assertThat(tokenStream.peek(i).getType()).isEqualTo(Type.PRINT_START);
+    assertThat(tokenStream.peek(i++).getValue()).isNull();
+
+    assertThat(tokenStream.peek(i).getType()).isEqualTo(Type.NAME);
+    assertThat(tokenStream.peek(i++).getValue()).isEqualTo("is_active");
+
+    assertThat(tokenStream.peek(i).getType()).isEqualTo(Type.OPERATOR);
+    assertThat(tokenStream.peek(i++).getValue()).isEqualTo("+");
+
+    assertThat(tokenStream.peek(i).getType()).isEqualTo(Type.NAME);
+    assertThat(tokenStream.peek(i++).getValue()).isEqualTo("contains0");
+
+    assertThat(tokenStream.peek(i).getType()).isEqualTo(Type.PRINT_END);
+    assertThat(tokenStream.peek(i++).getValue()).isEqualTo("}}");
+
+    assertThat(tokenStream.peek(i).getType()).isEqualTo(Type.EOF);
+    assertThat(tokenStream.peek(i++).getValue()).isNull();
+  }
+
+  /**
    * Test tokenizing Punctuation, such as the dot in item.itemType
    */
   @Test


### PR DESCRIPTION
Resolves #518 

Regex checking if operator is part of variable name looks only for letters whereas variable name can also have digits and underscore.

Example of valid variable names that were failing:
- is_active
- is0