### PR TITLE
Support all Java identifiers

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -89,7 +89,7 @@ public final class LexerImpl implements Lexer {
   /**
    * Static regular expressions for names, numbers, and punctuation.
    */
-  private static final Pattern REGEX_NAME = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*");
+  private static final Pattern REGEX_NAME = Pattern.compile("^\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*");
 
   private static final Pattern REGEX_LONG = Pattern.compile("^[0-9]+L");
 

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -89,7 +89,7 @@ public final class LexerImpl implements Lexer {
   /**
    * Static regular expressions for names, numbers, and punctuation.
    */
-  private static final Pattern REGEX_NAME = Pattern.compile("^\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*");
+  private static final Pattern REGEX_NAME = Pattern.compile("^[\\p{IsLetter}_][\\p{IsLetter}\\p{IsDigit}_]*");
 
   private static final Pattern REGEX_LONG = Pattern.compile("^[0-9]+L");
 

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -87,9 +87,9 @@ public final class LexerImpl implements Lexer {
   private boolean trimLeadingWhitespaceFromNextData = false;
 
   /**
-   * Static regular expressions for names, numbers, and punctuation.
+   * Static regular expressions for identifiers.
    */
-  private static final Pattern REGEX_NAME = Pattern.compile("^[\\p{IsLetter}_][\\p{IsLetter}\\p{IsDigit}_]*");
+  private static final Pattern REGEX_IDENTIFIER = Pattern.compile("^[\\p{IsLetter}_][\\p{IsLetter}\\p{IsDigit}_]*");
 
   private static final Pattern REGEX_LONG = Pattern.compile("^[0-9]+L");
 
@@ -414,7 +414,7 @@ public final class LexerImpl implements Lexer {
     }
 
     // names
-    matcher = REGEX_NAME.matcher(this.source);
+    matcher = REGEX_IDENTIFIER.matcher(this.source);
     if (matcher.lookingAt()) {
       token = this.source.substring(matcher.end());
       this.pushToken(Token.Type.NAME, token);

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/lexer/IdentifierTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/lexer/IdentifierTest.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.mitchellbosecke.pebble.lexer;
+
+import com.mitchellbosecke.pebble.error.ParserException;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IdentifierTest {
+
+  @Test
+  void common() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+    HashMap<String, Object> context = new HashMap<>();
+    context.put("fromContext", "ing");
+    StringWriter writer = new StringWriter();
+    pebble.getTemplate("{% set hello1 = \"test\" %}{{ hello1 }}{{ fromContext }}").evaluate(writer, context);
+    assertEquals("testing", writer.toString());
+  }
+
+  @Test
+  void digitStart() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+    StringWriter writer = new StringWriter();
+    assertThrows(ParserException.class, () -> pebble.getTemplate("{{ 0digit }}").evaluate(writer));
+  }
+
+  @Test
+  void extendedLatin() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+    HashMap<String, Object> context = new HashMap<>();
+    context.put("éabcêwçłë_0", "test string");
+    StringWriter writer = new StringWriter();
+    pebble.getTemplate("{{ éabcêwçłë_0 }}").evaluate(writer, context);
+    assertEquals("test string", writer.toString());
+  }
+
+  @Test
+  void arabic() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+    HashMap<String, Object> context = new HashMap<>();
+    context.put("شششش", "test string");
+    StringWriter writer = new StringWriter();
+    pebble.getTemplate("{{ شششش }}").evaluate(writer, context);
+    assertEquals("test string", writer.toString());
+  }
+
+  @Test
+  void chinese() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+    HashMap<String, Object> context = new HashMap<>();
+    context.put("水", "test string");
+    StringWriter writer = new StringWriter();
+    pebble.getTemplate("{{ 水 }}").evaluate(writer, context);
+    assertEquals("test string", writer.toString());
+  }
+}

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/lexer/IdentifierTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/lexer/IdentifierTest.java
@@ -8,6 +8,7 @@
  */
 package com.mitchellbosecke.pebble.lexer;
 
+import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.error.ParserException;
 import com.mitchellbosecke.pebble.loader.StringLoader;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Fixes #545.

This is needed to call methods or use fields that are not a-z characters, for example éêȩ etc.

These are supported in Java and because Java provides useful patterns for matching starts and parts of identifiers it's better to just use them.

This issue is really important as it prevents completely valid code from running.