### PR TITLE
Ability to check for presence of variables from EvaluationContext

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContext.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContext.java
@@ -12,4 +12,6 @@ public interface EvaluationContext {
   Locale getLocale();
 
   Object getVariable(String key);
+
+  boolean containsVariable(String key);
 }

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContextImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/template/EvaluationContextImpl.java
@@ -277,6 +277,11 @@ public class EvaluationContextImpl implements EvaluationContext, RenderedSizeCon
     return this.scopeChain.get(key);
   }
 
+  @Override
+  public boolean containsVariable(String key) {
+    return this.scopeChain.containsKey(key);
+  }
+
   private void pushScope(
           EvaluationContextImpl newContext,
           Map<?, ?> additionalVariables,

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/ContainsVariableTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/ContainsVariableTest.java
@@ -1,0 +1,43 @@
+package com.mitchellbosecke.pebble;
+
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.EvaluationContextImpl;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContainsVariableTest {
+
+	@Test
+	public void containsVariable() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(false).build();
+		HashMap<String, Object> map = new HashMap<>();
+		map.put("something", "ok");
+		map.put("valueNull", null);
+		StringWriter writer = new StringWriter();
+		PebbleTemplate template = pebble.getTemplate("");
+
+		Method initContext = PebbleTemplateImpl.class.getDeclaredMethod("initContext", Locale.class);
+		initContext.setAccessible(true);
+		Method evaluate = PebbleTemplateImpl.class.getDeclaredMethod("evaluate", Writer.class, EvaluationContextImpl.class);
+		evaluate.setAccessible(true);
+
+		EvaluationContextImpl context = (EvaluationContextImpl) initContext.invoke(template, new Object[] { null });
+		context.getScopeChain().pushScope(map);
+		evaluate.invoke(template, writer, context);
+
+		assertTrue(context.containsVariable("something"));
+		assertTrue(context.containsVariable("valueNull"));
+		assertFalse(context.containsVariable("whatever"));
+	}
+}


### PR DESCRIPTION
Currently getVariable returns null for non-present variables, so you can't know if the value is null or if it doesn't exist.
This pull request adds a containsVariable method to fix this.