### PR TITLE
Extension global variables in macros

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/node/MacroNode.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/node/MacroNode.java
@@ -72,6 +72,10 @@ public class MacroNode extends AbstractRenderableNode {
 
         // scope for default arguments
         scopeChain.pushLocalScope();
+        
+        // global vars provided by extensions
+        context.getExtensionRegistry().getGlobalVariables().forEach(scopeChain::put);
+        
         for (NamedArgumentNode arg: MacroNode.this.getArgs().getNamedArgs()) {
           Expression<?> valueExpression = arg.getValueExpression();
           if (valueExpression == null) {

--- a/pebble/src/test/java/com/mitchellbosecke/pebble/macro/MacroGlobalVariablesTest.java
+++ b/pebble/src/test/java/com/mitchellbosecke/pebble/macro/MacroGlobalVariablesTest.java
@@ -1,0 +1,33 @@
+package com.mitchellbosecke.pebble.macro;
+
+import com.mitchellbosecke.pebble.PebbleEngine;
+import com.mitchellbosecke.pebble.extension.AbstractExtension;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MacroGlobalVariablesTest {
+
+  public static final class Extension extends AbstractExtension {
+    @Override
+    public Map<String, Object> getGlobalVariables() {
+      HashMap<String, Object> map = new HashMap<>();
+      map.put("someGlobalValue", 18181);
+      return map;
+    }
+  }
+
+  @Test
+  void test() throws IOException {
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(new StringLoader()).strictVariables(true).extension(new Extension()).build();
+    StringWriter writer = new StringWriter();
+    pebble.getTemplate("{% macro m() %}{{ someGlobalValue }}{% endmacro %}{{ m() }}").evaluate(writer);
+    assertEquals("18181", writer.toString());
+  }
+}


### PR DESCRIPTION
Fixes #500

This change allows macros to use extension global variables (getGlobalVariables).