### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+cache:
+  directories:
+  - $HOME/.m2
 addons:
   apt:
     packages:


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.