### PR TITLE
Fix for older Android versions

### DIFF
--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -92,7 +92,7 @@ public final class LexerImpl implements Lexer {
   private static final Pattern REGEX_IDENTIFIER;
   
   static {
-    if ("The Android Project".equals(System.getProperty("java.vendor")) {
+    if ("The Android Project".equals(System.getProperty("java.vendor"))) {
       REGEX_IDENTIFIER = Pattern.compile("^[\\p{Letter}_][\\p{Letter}\\p{Digit}_]*");
     } else {
       // Standard

--- a/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
+++ b/pebble/src/main/java/com/mitchellbosecke/pebble/lexer/LexerImpl.java
@@ -89,8 +89,16 @@ public final class LexerImpl implements Lexer {
   /**
    * Static regular expressions for identifiers.
    */
-  private static final Pattern REGEX_IDENTIFIER = Pattern
-      .compile("^[\\p{IsAlphabetic}_][\\p{IsAlphabetic}\\p{Digit}_]*");
+  private static final Pattern REGEX_IDENTIFIER;
+  
+  static {
+    if ("The Android Project".equals(System.getProperty("java.vendor")) {
+      REGEX_IDENTIFIER = Pattern.compile("^[\\p{Letter}_][\\p{Letter}\\p{Digit}_]*");
+    } else {
+      // Standard
+      REGEX_IDENTIFIER = Pattern.compile("^[\\p{IsLetter}_][\\p{IsLetter}\\p{IsDigit}_]*");
+    }
+  }
 
   private static final Pattern REGEX_LONG = Pattern.compile("^[0-9]+L");
 


### PR DESCRIPTION
Fixes #580

A static initializer check for Android to support older android devices which do not support the standard names.