### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <licenses>
@@ -66,6 +67,7 @@
         <version>2.22.1</version>
         <configuration>
           <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.pebbletemplates</groupId>
   <artifactId>pebble-project</artifactId>
   <version>3.2.0-SNAPSHOT</version>
-  
+
   <packaging>pom</packaging>
 
   <modules>
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-  	<closeTestReports>true</closeTestReports>
+    <closeTestReports>true</closeTestReports>
   </properties>
 
   <licenses>
@@ -67,7 +67,7 @@
         <version>2.22.1</version>
         <configuration>
           <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+          <disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
