### PR TITLE
added loader that works from memory

### DIFF
--- a/docs/src/orchid/resources/changelog/v3_2_0.md
+++ b/docs/src/orchid/resources/changelog/v3_2_0.md
@@ -3,7 +3,10 @@ version: '3.2.0'
 ---
 
 - Add support for spring framework 6 and spring-boot 3 (#630)
-- Bump minimum supported java version to 17 in pebble-spring6 and pebble-spring-boot-starter in order to work with spring (#630)
+- Bump minimum supported java version to 17 in pebble-spring6 and pebble-spring-boot-starter in order to work with
+  spring (#630)
+- Add a memory loader that supports inheritance and doesn't require a filesystem. This is useful for applications
+  that retrieve templates from a database for example (#617).
 - **BREAKING CHANGE**: Change default suffix to `.peb` instead of `.pebble` in spring boot autoconfiguration (#553)
 - **BREAKING CHANGE**: Rename method `getInstance` to `createInstance` in `BinaryOperator` interface (#521)
 - **BREAKING CHANGE**: Rename package from `com.mitchellbosecke` to `io.pebbletemplates` (#635)

--- a/docs/src/orchid/resources/wiki/guide/installation.md
+++ b/docs/src/orchid/resources/wiki/guide/installation.md
@@ -68,6 +68,8 @@ application server but is not enabled by default.
 - `Servlet5Loader`:  Same as `ServletLoader`, but for Jakarta Servlet 5.0 or newer.
 - `StringLoader`: Considers the name of the template to be the contents of the template.
 - `DelegatingLoader`: Delegates responsibility to a collection of children loaders.
+- `MemoryLoader`: Loader that supports inheritance and doesn't require a filesystem. This is useful for applications
+  that retrieve templates from a database for example.
 
 If you do not provide a custom Loader, Pebble will use an instance of the `DelegatingLoader` by default.
 This delegating loader will use a `ClasspathLoader` and a `FileLoader` behind the scenes to find your templates.

--- a/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
@@ -1,95 +1,82 @@
 package io.pebbletemplates.pebble.loader;
 
+import io.pebbletemplates.pebble.error.LoaderException;
+
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Hashtable;
-import com.mitchellbosecke.pebble.error.LoaderException;
+import java.util.List;
 
 public class MemoryLoader implements Loader<String> {
-    private String prefix;
+    private final List<TemplateDefinition> templateDefinitions = new ArrayList<>();
 
-    private String suffix;
-
-    private String charset = "UTF-8";
-
-    ArrayList<Hashtable<String, String>> fileTable = new ArrayList<>();
-
-    public Reader getReader(String templateName)
-    {
+    @Override
+    public Reader getReader(String templateName) {
         String content = "";
-        for (Hashtable<String, String> hashtable : fileTable)
-        {
-            if(hashtable.containsKey("templateName"))
-            {
-                if(hashtable.get("templateName").equals(templateName))
-                {
-                    content = hashtable.get("content");
-                    break;
-                }
+        for (TemplateDefinition templateDefinition : this.templateDefinitions) {
+            if (templateDefinition.templateName.equals(templateName)) {
+                content = templateDefinition.content;
+                break;
             }
         }
 
-        if(content.isEmpty())
-        {
-            throw new LoaderException(null, "Could not find template \"" + templateName + "\""); //XSS?
+        if (content.isEmpty()) {
+            throw new LoaderException(null, "Could not find template \"" + templateName + "\"");
         }
 
         return new StringReader(content);
     }
 
-    public void addFile(String templateName, String content)
-    {
-        Hashtable<String, String> table = new Hashtable<>();
-        table.put("templateName", templateName);
-        table.put("content", content);
-        fileTable.add(table);
+    public void addTemplate(String templateName, String content) {
+        if (templateName == null) {
+            throw new IllegalArgumentException("templateName cannot be null");
+        }
+        if (content == null) {
+            throw new IllegalArgumentException("content cannot be null");
+        }
+        this.templateDefinitions.add(new TemplateDefinition(templateName, content));
     }
 
-    public String getSuffix() {
-        return this.suffix;
-    }
-
+    @Override
     public void setSuffix(String suffix) {
-        this.suffix = suffix;
     }
 
-    public String getPrefix() {
-        return this.prefix;
-    }
-
+    @Override
     public void setPrefix(String prefix) {
-        this.prefix = prefix;
     }
 
-    public String getCharset() {
-        return this.charset;
-    }
-
+    @Override
     public void setCharset(String charset) {
-        this.charset = charset;
     }
 
+    @Override
     public String resolveRelativePath(String relativePath, String anchorPath) {
         return relativePath; // hierarchy is flat
     }
 
+    @Override
     public String createCacheKey(String templateName) {
         return templateName;
     }
 
-    public boolean resourceExists(String templateName)
-    {
-        for (Hashtable<String, String> hashtable : fileTable)
-        {
-            if(hashtable.containsKey("templateName"))
-            {
-                if(hashtable.get("templateName").equals(templateName))
-                {
-                    return true;
-                }
+    @Override
+    public boolean resourceExists(String templateName) {
+        for (TemplateDefinition templateDefinition : this.templateDefinitions) {
+            if (templateDefinition.templateName.equals(templateName)) {
+                return true;
             }
         }
         return false;
+    }
+
+    private static class TemplateDefinition {
+        public final String templateName;
+        public final String content;
+
+        public TemplateDefinition(String templateName,
+                                  String content) {
+            this.templateName = templateName;
+            this.content = content;
+        }
     }
 }

--- a/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
@@ -1,0 +1,95 @@
+package io.pebbletemplates.pebble.loader;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import com.mitchellbosecke.pebble.error.LoaderException;
+
+public class MemoryLoader implements Loader<String> {
+    private String prefix;
+
+    private String suffix;
+
+    private String charset = "UTF-8";
+
+    ArrayList<Hashtable<String, String>> fileTable = new ArrayList<>();
+
+    public Reader getReader(String templateName)
+    {
+        String content = "";
+        for (Hashtable<String, String> hashtable : fileTable)
+        {
+            if(hashtable.containsKey("templateName"))
+            {
+                if(hashtable.get("templateName").equals(templateName))
+                {
+                    content = hashtable.get("content");
+                    break;
+                }
+            }
+        }
+
+        if(content.isEmpty())
+        {
+            throw new LoaderException(null, "Could not find template \"" + templateName + "\""); //XSS?
+        }
+
+        return new StringReader(content);
+    }
+
+    public void addFile(String templateName, String content)
+    {
+        Hashtable<String, String> table = new Hashtable<>();
+        table.put("templateName", templateName);
+        table.put("content", content);
+        fileTable.add(table);
+    }
+
+    public String getSuffix() {
+        return this.suffix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getCharset() {
+        return this.charset;
+    }
+
+    public void setCharset(String charset) {
+        this.charset = charset;
+    }
+
+    public String resolveRelativePath(String relativePath, String anchorPath) {
+        return relativePath; // hierarchy is flat
+    }
+
+    public String createCacheKey(String templateName) {
+        return templateName;
+    }
+
+    public boolean resourceExists(String templateName)
+    {
+        for (Hashtable<String, String> hashtable : fileTable)
+        {
+            if(hashtable.containsKey("templateName"))
+            {
+                if(hashtable.get("templateName").equals(templateName))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/pebble/src/test/java/io/pebbletemplates/pebble/LoaderTest.java
+++ b/pebble/src/test/java/io/pebbletemplates/pebble/LoaderTest.java
@@ -17,17 +17,14 @@ import io.pebbletemplates.pebble.loader.Loader;
 import io.pebbletemplates.pebble.loader.StringLoader;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -106,6 +103,22 @@ class LoaderTest {
     template.evaluate(writer);
 
     assertEquals("LOADER ONE", writer.toString());
+  }
+
+  @Test
+  void testMemoryLoader() throws PebbleException, IOException, URISyntaxException {
+    MemoryLoader loader = new MemoryLoader();
+    loader.setSuffix(".suffix");
+    PebbleEngine engine = new PebbleEngine.Builder().loader(loader).strictVariables(false).build();
+    URL url = this.getClass().getResource("/templates/template.loaderTest.peb");
+    String content = FileUtils.readFileToString(new File(url.toURI()), StandardCharsets.UTF_8);
+
+    loader.addFile("main", content);
+    PebbleTemplate template1 = engine.getTemplate("main");
+    Writer writer1 = new StringWriter();
+    template1.evaluate(writer1);
+    assertEquals("SUCCESS", writer1.toString());
+
   }
 
   @Test

--- a/pebble/src/test/java/io/pebbletemplates/pebble/LoaderTest.java
+++ b/pebble/src/test/java/io/pebbletemplates/pebble/LoaderTest.java
@@ -10,21 +10,14 @@ package io.pebbletemplates.pebble;
 
 import io.pebbletemplates.pebble.error.LoaderException;
 import io.pebbletemplates.pebble.error.PebbleException;
-import io.pebbletemplates.pebble.loader.ClasspathLoader;
-import io.pebbletemplates.pebble.loader.DelegatingLoader;
-import io.pebbletemplates.pebble.loader.FileLoader;
-import io.pebbletemplates.pebble.loader.Loader;
-import io.pebbletemplates.pebble.loader.StringLoader;
+import io.pebbletemplates.pebble.loader.*;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
-
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -106,19 +99,33 @@ class LoaderTest {
   }
 
   @Test
-  void testMemoryLoader() throws PebbleException, IOException, URISyntaxException {
+  void testMemoryLoader() throws PebbleException, IOException {
     MemoryLoader loader = new MemoryLoader();
-    loader.setSuffix(".suffix");
-    PebbleEngine engine = new PebbleEngine.Builder().loader(loader).strictVariables(false).build();
-    URL url = this.getClass().getResource("/templates/template.loaderTest.peb");
-    String content = FileUtils.readFileToString(new File(url.toURI()), StandardCharsets.UTF_8);
+    PebbleEngine pebble = new PebbleEngine.Builder().loader(loader).strictVariables(false).build();
 
-    loader.addFile("main", content);
-    PebbleTemplate template1 = engine.getTemplate("main");
-    Writer writer1 = new StringWriter();
-    template1.evaluate(writer1);
-    assertEquals("SUCCESS", writer1.toString());
+    loader.addTemplate("home.html", "{% extends \"layout.html\" %}{% block title %} Home {% endblock %}"
+            + "{% block content %}"
+            + "<h1> Home </h1>"
+            + "<p> Welcome to my home page. My name is {{ name }}.</p>"
+            + "{% endblock %}");
+    loader.addTemplate("layout.html", "<html>"
+            + "<head>"
+            + "<title>Hello Pebble</title>"
+            + "</head>"
+            + "<body>"
+            + "{% block content %}{% endblock %}"
+            + "</body>"
+            + "</html>");
 
+    PebbleTemplate template = pebble.getTemplate("home.html");
+
+    Map<String, Object> context = new HashMap<>();
+    context.put("name", "Bob");
+
+    Writer writer = new StringWriter();
+    template.evaluate(writer, context);
+
+    assertEquals("<html><head><title>Hello Pebble</title></head><body><h1> Home </h1><p> Welcome to my home page. My name is Bob.</p></body></html>", writer.toString());
   }
 
   @Test


### PR DESCRIPTION
This attempts to solve the issue with StringLoader where inheritance is not supported.  This loader uses a flat hierarchy.

```
MemoryLoader memLoader = new MemoryLoader();
memLoader.addFile("home.html", "{% extends \"layout.html\" %}{% block title %} Home {% endblock %}\r\n"
			+ "\r\n"
			+ "{% block content %}\r\n"
			+ "	<h1> Home </h1>\r\n"
			+ "	<p> Welcome to my home page. My name is {{ name }}.</p>\r\n"
			+ "{% endblock %}");
memLoader.addFile("layout.html", "<!DOCTYPE html>\r\n"
		+ "<html>\r\n"
		+ "    <head>\r\n"
		+ "        <title>Hello Pebble</title>\r\n"
		+ "    </head>\r\n"
		+ "    <body>\r\n"
		+ "        {% block content %}{% endblock %}\r\n"
		+ "    </body>\r\n"
		+ "</html>");
PebbleEngine engine = new PebbleEngine.Builder().loader(memLoader).build();
PebbleTemplate compiledTemplate = engine.getTemplate("home.html");
Map<String, Object> context = new HashMap<String, Object>();
context.put("name", "Mitchell");

Writer writer = new StringWriter();
compiledTemplate.evaluate(writer, context);

String output = writer.toString();
System.out.println(output)
```;