### PR TITLE
i18n-alias - adding i18 function alias with `messages` bundle as default

### DIFF
--- a/pebble/src/main/java/io/pebbletemplates/pebble/extension/i18n/I18nExtension.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/extension/i18n/I18nExtension.java
@@ -20,7 +20,8 @@ public class I18nExtension extends AbstractExtension {
   public Map<String, Function> getFunctions() {
     Map<String, Function> functions = new HashMap<>();
     functions.put("i18n", new i18nFunction());
+    functions.put("t", new i18nAliasFunction());
+
     return functions;
   }
-
 }

--- a/pebble/src/main/java/io/pebbletemplates/pebble/extension/i18n/i18nAliasFunction.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/extension/i18n/i18nAliasFunction.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Pebble.
+ *
+ * Copyright (c) 2014 by Mitchell Bösecke
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package io.pebbletemplates.pebble.extension.i18n;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.pebbletemplates.pebble.template.EvaluationContext;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
+
+public class i18nAliasFunction extends i18nFunction {
+    
+    private final List<String> argumentNames = new ArrayList<>();
+
+    public i18nAliasFunction() {
+        this.argumentNames.add("key");
+        this.argumentNames.add("params");
+    }
+
+    @Override
+    public List<String> getArgumentNames() {
+        return this.argumentNames;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
+        args.put("bundle", "messages");
+
+        return super.execute(args, self, context, lineNumber);
+    }
+}


### PR DESCRIPTION
Most of the time there is only one bundle - `messages`, so this shortcut/alias is really useful for that cases.