### PR TITLE
Support Beans#get with Class

### DIFF
--- a/pebble-spring/pebble-spring5/src/main/java/io/pebbletemplates/spring/context/Beans.java
+++ b/pebble-spring/pebble-spring5/src/main/java/io/pebbletemplates/spring/context/Beans.java
@@ -56,6 +56,9 @@ public class Beans implements Map<String, Object> {
   @Override
   public Object get(Object key) {
     Assert.notNull(key, "Key cannot be null");
+    if (key instanceof Class<?>) {
+      return this.ctx.getBean((Class<?>) key);
+    }
     return this.ctx.getBean(key.toString());
   }
 

--- a/pebble-spring/pebble-spring6/src/main/java/io/pebbletemplates/spring/context/Beans.java
+++ b/pebble-spring/pebble-spring6/src/main/java/io/pebbletemplates/spring/context/Beans.java
@@ -56,6 +56,9 @@ public class Beans implements Map<String, Object> {
   @Override
   public Object get(Object key) {
     Assert.notNull(key, "Key cannot be null");
+    if (key instanceof Class<?> keyAsClass) {
+      return this.ctx.getBean(keyAsClass);
+    }
     return this.ctx.getBean(key.toString());
   }
 


### PR DESCRIPTION
Instead of always calling toString, allow getting a bean by Class. This is a rare use case, but we would like to use it for example in an Extension on the Java side which needs to get beans from Spring context.