### PR TITLE
Added getTemplates function to MemoryLoader

### DIFF
--- a/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
@@ -37,6 +37,10 @@ public class MemoryLoader implements Loader<String> {
         this.templateDefinitions.add(new TemplateDefinition(templateName, content));
     }
 
+    public List<TemplateDefinition> getTemplates() {
+        return this.templateDefinitions;
+    }
+
     @Override
     public void setSuffix(String suffix) {
     }

--- a/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/loader/MemoryLoader.java
@@ -73,7 +73,7 @@ public class MemoryLoader implements Loader<String> {
         return false;
     }
 
-    private static class TemplateDefinition {
+    public static class TemplateDefinition {
         public final String templateName;
         public final String content;
 


### PR DESCRIPTION
**Summary**
This Pull Request adds a new method getTemplates() to the MemoryLoader class. The method is designed to return a list of all the existing templates currently loaded in memory.

**Background**
In applications that dynamically generate or update Pebble templates, it is often necessary to get a list of all existing templates. However, the MemoryLoader class lacks a method for obtaining this information, which could lead to inefficiencies and limitations in application development.

**Changes**
Added a new method getTemplates() in MemoryLoader class.
Updated relevant unit tests (if applicable).

**Use Case**
This feature will be useful in scenarios where developers need to:

Debug or log currently loaded templates.
Implement functionality that depends on the list of loaded templates.