### PR TITLE
Generate OSGi metadata into pebble jar to make it OSGi compliant

### DIFF
--- a/pebble/pom.xml
+++ b/pebble/pom.xml
@@ -90,12 +90,36 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>7.0.0</version>
+        <executions>
+          <execution>
+            <id>generate-osgi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+                Bundle-SymbolicName: io.pebbletemplates.pebble
+                Automatic-Module-Name: io.pebbletemplates
+                Import-Package: \
+                  com.github.benmanes.caffeine.*;version="[2.6,4)";resolution:=optional, \
+                  javax.servlet;version="[2.5,5)";resolution:=optional, \
+                  jakarta.servlet;version="[5.0,7)";resolution:=optional, \
+                  *
+                -exportcontents: *;-noimport:=true
+                -noextraheaders: true
+              ]]></bnd>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>io.pebbletemplates</Automatic-Module-Name>
-            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
This allows to use the pebble jar in an OSGi runtime, like Eclipse, out of the box.

The version ranges for the optional dependencies `com.github.ben-manes.caffeine:caffeine`, `javax.servlet` and `jakarta.servlet` have been widened manually because there are newer versions available than the one this library depends on.

If you are interested in updating any of these dependencies (and especially migrate `javax.servlet:servlet-api` to `javax.servlet:javax.servlet-api` or even `jakarta.servlet:jakarta.servlet-api:4.0.2` (which provides the `javax.servlet` packages) I can provide a separate PR or do it in this one.

The OSGi compliant MANIFEST.MF is only generated for the main `pebble` artifact.
If you think this is also relevant for the spring artifacts I can extend the change, but I would not be able to test the result.