### PR TITLE
Add  flag for parameter name retention in maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What
Add  flag for parameter name retention in maven compiler plugin.

## Why
As of https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention, it is recommend to add the flag as `LocalVariableTableParameterNameDiscoverer has been removed in 6.1` to be compatible with Spring Boot 3.2.x version (and Spring Framework 6.1.x version)!