### PR TITLE
Fix the ability to provide your own PebbleViewResolver

### DIFF
--- a/pebble-spring/pebble-spring-boot-starter/src/main/java/io/pebbletemplates/boot/autoconfigure/PebbleReactiveWebConfiguration.java
+++ b/pebble-spring/pebble-spring-boot-starter/src/main/java/io/pebbletemplates/boot/autoconfigure/PebbleReactiveWebConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 class PebbleReactiveWebConfiguration extends AbstractPebbleConfiguration {
 
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(name = "pebbleReactiveViewResolver")
   PebbleReactiveViewResolver pebbleReactiveViewResolver(PebbleProperties properties,
       PebbleEngine pebbleEngine) {
     String prefix = properties.getPrefix();

--- a/pebble-spring/pebble-spring-boot-starter/src/main/java/io/pebbletemplates/boot/autoconfigure/PebbleServletWebConfiguration.java
+++ b/pebble-spring/pebble-spring-boot-starter/src/main/java/io/pebbletemplates/boot/autoconfigure/PebbleServletWebConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 class PebbleServletWebConfiguration extends AbstractPebbleConfiguration {
 
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(name = "pebbleViewResolver")
   PebbleViewResolver pebbleViewResolver(PebbleProperties properties,
       PebbleEngine pebbleEngine) {
     PebbleViewResolver pvr = new PebbleViewResolver(pebbleEngine);


### PR DESCRIPTION
The [documentation](https://github.com/search?q=repo:PebbleTemplates/pebble%20Customizing%20the%20ViewResolver&type=code#L110-L117) states we can provide our own `PebbleViewResolver`.

I'm upgrading from Pebble 3.1.0 to the latest 3.2.2, and my `@Bean` for my custom PebbleViewResolver breaks.

Starting the Spring Boot server (version 3.4.2) fails with:

```
The bean 'pebbleViewResolver', defined in class path resource [io/pebbletemplates/boot/autoconfigure/PebbleServletWebConfiguration.class], could not be registered. A bean with that name has already been defined in class path resource [com/myproject/extension/PebbleConfiguration.class] and overriding is disabled.
```

Pebble 3.1.0 had the correct implementation: `@ConditionalOnMissingBean(name = "pebbleViewResolver")`
Whereas 3.2.2 has `@ConditionalOnMissingBean`.
 - When the `name` is set, it allows the bean to come from anywhere.
 - When it is not set, it implies the provided bean must match the exact class return type of the method annotated, or be a derived class of the return type.

Workarounds?
 - I attempted to exclude the Configuration class `PebbleServletWebConfiguration` but that was not possible since the scope of that class is not public.
 - I could try to subclass the original `PebbleViewResolver`, but that has a different problem of forcing me to still use the built in `PebbleView` and not my custom View.