### PR TITLE
Fix the problem of not resolving reactive values in models

### DIFF
--- a/pebble-spring/pebble-spring-boot-starter/src/test/java/io/pebbletemplates/boot/Controllers.java
+++ b/pebble-spring/pebble-spring-boot-starter/src/test/java/io/pebbletemplates/boot/Controllers.java
@@ -2,6 +2,7 @@ package io.pebbletemplates.boot;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.WebSession;
 
 @Controller
 public class Controllers {
@@ -29,6 +30,12 @@ public class Controllers {
   @RequestMapping("/beans.action")
   public String beans() {
     return "beans";
+  }
+
+  @RequestMapping("/session.action")
+  public String session(WebSession session) {
+    session.getAttributes().put("foo", "bar");
+    return "session";
   }
 
   @RequestMapping("/response.action")

--- a/pebble-spring/pebble-spring-boot-starter/src/test/java/io/pebbletemplates/boot/autoconfigure/ReactiveAppTest.java
+++ b/pebble-spring/pebble-spring-boot-starter/src/test/java/io/pebbletemplates/boot/autoconfigure/ReactiveAppTest.java
@@ -96,5 +96,16 @@ class ReactiveAppTest {
 
     assertThat(result).isEqualTo("response:200 OK");
   }
+
+  @Test
+  void testSessionAccess() {
+    String result = this.client.get().uri("/session.action").exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_HTML)
+            .expectBody(String.class)
+            .returnResult().getResponseBody();
+
+    assertThat(result).isEqualTo("session:bar");
+  }
 }
 

--- a/pebble-spring/pebble-spring-boot-starter/src/test/resources/templates/session.peb
+++ b/pebble-spring/pebble-spring-boot-starter/src/test/resources/templates/session.peb
@@ -1,0 +1,1 @@
+session:{{ session.attributes.foo }}


### PR DESCRIPTION
This PR tries to fix the problem described at <https://github.com/PebbleTemplates/pebble/pull/513#discussion_r2002957400>.

I override the method `getModelAttributes` to resolve the async attributes automatically, please refer to [here](https://github.com/spring-projects/spring-framework/blob/a376ef36e42e078138c92d7cde6fde38dd426c04/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/AbstractView.java#L227).

At last, I added a unit test against the session resolution.