### PR TITLE
chore: expose ast root node (#701)

### DIFF
--- a/pebble/src/main/java/io/pebbletemplates/pebble/template/PebbleTemplate.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/template/PebbleTemplate.java
@@ -9,6 +9,7 @@
 package io.pebbletemplates.pebble.template;
 
 import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.node.RenderableNode;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -108,5 +109,11 @@ public interface PebbleTemplate {
    * @return The name of the template
    */
   String getName();
+
+  /**
+   * Returns the root node of the template
+   * @return The name of the template
+   */
+  RenderableNode getRootNode();
 
 }

--- a/pebble/src/main/java/io/pebbletemplates/pebble/template/PebbleTemplateImpl.java
+++ b/pebble/src/main/java/io/pebbletemplates/pebble/template/PebbleTemplateImpl.java
@@ -535,6 +535,13 @@ public class PebbleTemplateImpl implements PebbleTemplate {
     return this.name;
   }
 
+  /**
+   * Returns the root node of the template AST
+   *
+   * @return The root node of the template AST
+   */
+  public RenderableNode getRootNode() { return this.rootNode; }
+
   private static class NoopWriter extends Writer {
 
     public void write(char[] cbuf, int off, int len) {


### PR DESCRIPTION
This PR adds as part of the `PebbleTemplate` interface the method `getRoot()` in order to expose the root node.
 Closes: #701 