### PR TITLE
Highlight current page from sidebar on wiki pages

### DIFF
--- a/docs/src/orchid/resources/templates/includes/sidebar.peb
+++ b/docs/src/orchid/resources/templates/includes/sidebar.peb
@@ -58,28 +58,3 @@
 
     </div>
 </div>
-
-<script>
-(function ($) {
-	$(function () {
-        const href = window.location.href.replace(/\/+$/, '');
-
-        if (!href.includes('/wiki/')) {
-            return;
-        }
-
-        const a = document.querySelector('#siteNav li li a[href="' + href + '"]');
-        const ul = a.closest('ul');
-        const li = ul.closest('li');
-        const span = li.querySelector(':scope > span');
-
-        a.classList.add('active');
-        a.style.color = '#72A6D0';
-        span.style.color = '#72A6D0';
-
-        setTimeout(function () {
-            span.click();
-        }, 0);
-    });
-}(jQuery));
-</script>

--- a/docs/src/orchid/resources/templates/layouts/index.peb
+++ b/docs/src/orchid/resources/templates/layouts/index.peb
@@ -50,6 +50,30 @@
 </div>
 
 {% scripts %}
+<script>
+(function ($) {
+	$(function () {
+        const href = window.location.href.replace(/\/+$/, '');
+
+        if (!href.includes('/wiki/')) {
+            return;
+        }
+
+        const a = document.querySelector('#siteNav li li a[href="' + href + '"]');
+        const ul = a.closest('ul');
+        const li = ul.closest('li');
+        const span = li.querySelector(':scope > span');
+
+        a.classList.add('active');
+        a.style.color = '#72A6D0';
+        span.style.color = '#72A6D0';
+
+        setTimeout(function () {
+            span.click();
+        }, 0);
+    });
+}(jQuery));
+</script>
 {% include '?trackingBodyEnd' %}
 </body>
 </html>


### PR DESCRIPTION
When browsing wiki pages, it is inconvenient to repeatedly reopen the accordion to navigate between pages.

This PR ensures that the currently active accordion in the WIKI section remains open and highlights the selected page.

For instance, while browsing this page: https://pebbletemplates.io/wiki/function/blockFunction/

The "FUNCTION" accordian will be opened and "BLOCK" will be highlighted automaticaly.

<img width="303" height="573" alt="image" src="https://github.com/user-attachments/assets/b7867a08-2039-4575-92e6-11d5ecf97e46" />
